### PR TITLE
CIS-3203: Initial implementation of the Notification Library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 		<relativePath />
 		<!-- lookup parent from repository -->
 	</parent>
@@ -43,6 +43,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
+		<common_lib.version>1.7.0</common_lib.version>
+		<messaginglib.version>0.1.0</messaginglib.version>
 	</properties>
 
 	<distributionManagement>
@@ -56,8 +58,26 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-batch</artifactId>
+		</dependency>
+  		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.octri.common</groupId>
+			<artifactId>common_lib</artifactId>
+			<version>${common_lib.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.octri.messaging</groupId>
+			<artifactId>messaging_lib</artifactId>
+			<version>${messaginglib.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/octri/notification/batch/NotificationBatchJob.java
+++ b/src/main/java/org/octri/notification/batch/NotificationBatchJob.java
@@ -1,0 +1,81 @@
+package org.octri.notification.batch;
+
+import org.octri.notification.domain.ProcessingMode;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.configuration.DuplicateJobException;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * The component that handles running the job if it's not already in progress
+ */
+@Component
+public class NotificationBatchJob {
+
+	private final JobExplorer jobExplorer;
+	private final JobLauncher jobLauncher;
+	private final Job notificationJob;
+
+	/**
+	 * 
+	 * @param jobExplorer
+	 *            the JobExplorer
+	 * @param jobLauncher
+	 *            the JobLauncher
+	 * @param notificationJob
+	 *            the notificationJob bean
+	 */
+	public NotificationBatchJob(JobExplorer jobExplorer, JobLauncher jobLauncher, Job notificationJob) {
+		this.jobExplorer = jobExplorer;
+		this.jobLauncher = jobLauncher;
+		this.notificationJob = notificationJob;
+	}
+
+	/**
+	 * Run the batch process for sending notifications
+	 * 
+	 * @param mode
+	 *            the job ProcessingMode
+	 * @throws Exception
+	 *             exception thrown by the jobLauncher
+	 */
+	public void runNotificationJob(ProcessingMode mode) throws Exception {
+		if (isJobRunning("notificationJob")) {
+			throw new DuplicateJobException("The notification job is already running.");
+		}
+		JobParameters jobParameters = new JobParametersBuilder()
+				.addLong("time", System.currentTimeMillis())
+				.addString("processingMode", mode.name())
+				.toJobParameters();
+		jobLauncher.run(notificationJob, jobParameters);
+	}
+
+	/**
+	 * Run the job to process IMMEDIATE notifications
+	 * 
+	 * @throws Exception
+	 *             exception thrown by the jobLauncher
+	 */
+	public void runImmediateNotificationJob() throws Exception {
+		runNotificationJob(ProcessingMode.IMMEDIATE);
+	}
+
+	/**
+	 * Run the job to process SCHEDULED notifications.
+	 * 
+	 * @throws Exception
+	 *             exception thrown by the jobLauncher
+	 */
+	@Scheduled(cron = "${octri.notifications.schedule:@yearly}")
+	public void runScheduledNotificationJob() throws Exception {
+		runNotificationJob(ProcessingMode.SCHEDULED);
+	}
+
+	private boolean isJobRunning(String jobName) {
+		return jobExplorer.findRunningJobExecutions(jobName).size() > 0;
+	}
+}

--- a/src/main/java/org/octri/notification/batch/NotificationItemProcessor.java
+++ b/src/main/java/org/octri/notification/batch/NotificationItemProcessor.java
@@ -1,0 +1,51 @@
+package org.octri.notification.batch;
+
+import org.octri.notification.domain.Notification;
+import org.octri.notification.domain.Notification.NotificationStatusMetadata;
+import org.octri.notification.domain.ValidationResult;
+import org.octri.notification.registry.NotificationTypeRegistry;
+import org.octri.notification.validator.NotificationValidator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ItemProcessor;
+
+/**
+ * The processor checks whether the Notification is still valid and persists the ValidationStatus back
+ */
+public class NotificationItemProcessor implements ItemProcessor<Notification, Notification> {
+
+	private static final Logger logger = LoggerFactory.getLogger(NotificationItemProcessor.class);
+
+	private final NotificationTypeRegistry notificationTypeRegistry;
+
+	/**
+	 * 
+	 * @param notificationTypeRegistry
+	 *            the notification type registry
+	 */
+	public NotificationItemProcessor(NotificationTypeRegistry notificationTypeRegistry) {
+		this.notificationTypeRegistry = notificationTypeRegistry;
+	}
+
+	@Override
+	public Notification process(Notification notification) {
+		logger.debug("Processing notification " + notification.getId());
+		ValidationResult validationResult = validate(notification);
+		if (!validationResult.successful()) {
+			logger.debug("Notification is no longer valid");
+		}
+		notification.setNotificationStatusMetadata(
+				new NotificationStatusMetadata(validationResult, null));
+		return notification;
+	}
+
+	private ValidationResult validate(Notification notification) {
+		var handler = notificationTypeRegistry.getHandler(notification.getNotificationType());
+		if (handler == null) {
+			return new ValidationResult(false, "The application does not support this notification type.");
+		}
+		NotificationValidator validator = handler.getValidator();
+		return validator.validate(notification);
+	}
+
+}

--- a/src/main/java/org/octri/notification/batch/NotificationItemReader.java
+++ b/src/main/java/org/octri/notification/batch/NotificationItemReader.java
@@ -1,0 +1,75 @@
+package org.octri.notification.batch;
+
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import org.octri.common.customizer.IdentifiableEntityFinder;
+import org.octri.notification.domain.DefaultNotificationStatus;
+import org.octri.notification.domain.Notification;
+import org.octri.notification.domain.ProcessingMode;
+import org.octri.notification.domain.Recipient;
+import org.octri.notification.registry.NotificationTypeRegistry;
+import org.octri.notification.repository.NotificationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ItemReader;
+
+/**
+ * The reader finds the notifications that are due for processing.
+ */
+public class NotificationItemReader implements ItemReader<Notification> {
+
+	private static final Logger logger = LoggerFactory.getLogger(NotificationItemReader.class);
+	private final NotificationTypeRegistry notificationTypeRegistry;
+	private final NotificationRepository notificationRepository;
+	private final ProcessingMode jobProcessingMode;
+	private final IdentifiableEntityFinder<?> recipientFinder;
+	private Iterator<Notification> notificationIterator;
+
+	/**
+	 * 
+	 * @param notificationTypeRegistry
+	 *            the notification type registry
+	 * @param notificationRepository
+	 *            the notification repository
+	 * @param recipientFinder
+	 *            the finder for recipients
+	 * @param jobProcessingMode
+	 *            the processing mode for the job
+	 */
+	public NotificationItemReader(NotificationTypeRegistry notificationTypeRegistry,
+			NotificationRepository notificationRepository, IdentifiableEntityFinder<?> recipientFinder,
+			ProcessingMode jobProcessingMode) {
+		this.notificationTypeRegistry = notificationTypeRegistry;
+		this.notificationRepository = notificationRepository;
+		this.recipientFinder = recipientFinder;
+		this.jobProcessingMode = jobProcessingMode;
+	}
+
+	@Override
+	public Notification read() {
+		if (notificationIterator == null) {
+			LocalDate today = LocalDate.now();
+			List<Notification> notifications = notificationRepository
+					.findByNotificationStatusAndDateScheduledLessThanEqual(DefaultNotificationStatus.SCHEDULED, today);
+			if (ProcessingMode.IMMEDIATE.equals(jobProcessingMode)) {
+				notifications = notifications.stream().filter(notification -> {
+					var handler = notificationTypeRegistry.getHandler(notification.getNotificationType());
+					// Let through types with a null handler. The error will get flagged in the processor.
+					return handler != null ? ProcessingMode.IMMEDIATE.equals(handler.getProcessingMode()) : true;
+				}).toList();
+			}
+			logger.debug(String.format("Reading %d past due scheduled notifications in %s processing mode",
+					notifications.size(), jobProcessingMode));
+			notificationIterator = notifications.iterator();
+		}
+		Notification notification = notificationIterator.hasNext() ? notificationIterator.next() : null;
+		if (notification != null) {
+			// Ensure the Recipient entity is set before processing
+			notification.setRecipient((Recipient) recipientFinder.findByUuid(notification.getRecipientUuid()));
+		}
+		return notification;
+	}
+
+}

--- a/src/main/java/org/octri/notification/batch/NotificationItemWriter.java
+++ b/src/main/java/org/octri/notification/batch/NotificationItemWriter.java
@@ -1,0 +1,150 @@
+package org.octri.notification.batch;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.octri.notification.domain.DefaultNotificationStatus;
+import org.octri.notification.domain.DispatchResult;
+import org.octri.notification.domain.Notification;
+import org.octri.notification.domain.Notification.NotificationStatusMetadata;
+import org.octri.notification.domain.ReminderDayProgressionTracker;
+import org.octri.notification.domain.ValidationResult;
+import org.octri.notification.registry.MissingHandlerException;
+import org.octri.notification.registry.NotificationTypeRegistry;
+import org.octri.notification.repository.NotificationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+/**
+ * The writer tries to send the notification if it is still valid and sets the status.
+ */
+public class NotificationItemWriter implements ItemWriter<Notification> {
+
+	private static final Logger logger = LoggerFactory.getLogger(NotificationItemWriter.class);
+	private final NotificationRepository notificationRepository;
+	private NotificationTypeRegistry notificationTypeRegistry;
+	private Set<String> dispatchedKeys = new HashSet<>();
+
+	/**
+	 * 
+	 * @param notificationRepository
+	 *            the notification repository
+	 * @param notificationTypeRegistry
+	 *            the notification type registry
+	 */
+	public NotificationItemWriter(NotificationRepository notificationRepository,
+			NotificationTypeRegistry notificationTypeRegistry) {
+		this.notificationRepository = notificationRepository;
+		this.notificationTypeRegistry = notificationTypeRegistry;
+	}
+
+	@Override
+	public void write(Chunk<? extends Notification> notifications) throws Exception {
+		for (Notification notification : notifications) {
+			var notificationStatusMetadata = notification.getStatusMetadata();
+			notification.setDateTimeProcessed(LocalDateTime.now());
+			if (isNotificationValid(notificationStatusMetadata)) {
+				var dispatchKey = notification.getDispatchKey();
+				if (dispatchedKeys.contains(dispatchKey)) {
+					var validationResult = new ValidationResult(false, "Duplicate notification - will not be sent.");
+					notification.setNotificationStatusMetadata(new NotificationStatusMetadata(validationResult, null));
+					notification = updateInvalidNotification(notification);
+				} else {
+					var handler = notificationTypeRegistry.getHandler(notification.getNotificationType());
+					if (handler == null) {
+						throw new MissingHandlerException(
+								String.format("No handler found for notification type: %s",
+										notification.getNotificationType()));
+					}
+					var dispatcher = handler.getDispatcher();
+					var dispatchResult = dispatcher.handleDispatch(notification);
+					if (notification
+							.getNotificationMetadata(
+									handler.getMetadataClass()) instanceof ReminderDayProgressionTracker) {
+						ReminderDayProgressionTracker progressionTracker = (ReminderDayProgressionTracker) notification
+								.getNotificationMetadata(handler.getMetadataClass());
+						Optional<Notification> nextNotification = nextNotification(notification, progressionTracker);
+						if (nextNotification.isPresent()) {
+							notificationRepository.save(nextNotification.get());
+						}
+					}
+					notification = updateDispatchedNotification(notification,
+							notificationStatusMetadata.validationResult(),
+							dispatchResult);
+					if (dispatchResult.successful()) {
+						dispatchedKeys.add(dispatchKey);
+					}
+				}
+			} else {
+				notification = updateInvalidNotification(notification);
+			}
+
+			notificationRepository.save(notification);
+		}
+	}
+
+	/**
+	 * Generate the next future Notification in the progression of reminders
+	 * 
+	 * @param notification
+	 * @param progressionTracker
+	 * @return
+	 * @throws JsonProcessingException
+	 */
+	static Optional<Notification> nextNotification(Notification notification,
+			ReminderDayProgressionTracker progressionTracker)
+			throws JsonProcessingException {
+
+		// Skip any notifications that fall in the past, advancing to the next future date in the progression tracker
+		while (!progressionTracker.isFinal()) {
+			progressionTracker.advance();
+			if (progressionTracker.getCurrentDate().isAfter(LocalDate.now())) {
+				logger.debug("Adding the next notification in the series.");
+				Notification copy = new Notification();
+				copy.setNotificationType(notification.getNotificationType());
+				copy.setRecipientUuid(notification.getRecipientUuid());
+				copy.setNotificationStatus(DefaultNotificationStatus.SCHEDULED);
+				copy.setDateScheduled(progressionTracker.getCurrentDate());
+				copy.setNotificationMetadata(notification.getObjectMapper().writeValueAsString(progressionTracker));
+				return Optional.of(copy);
+			}
+		}
+
+		return Optional.empty();
+	}
+
+	static boolean isNotificationValid(NotificationStatusMetadata notificationStatusMetadata) {
+		return notificationStatusMetadata.validationResult().successful();
+	}
+
+	static Notification updateInvalidNotification(Notification notification) {
+		logger.debug(String.format("Notification %s marked invalid", notification.getId()));
+		notification.setNotificationStatus(DefaultNotificationStatus.INACTIVE);
+		return notification;
+	}
+
+	static Notification updateDispatchedNotification(Notification notification,
+			ValidationResult validationResult,
+			DispatchResult dispatchResult) {
+		notification.setNotificationStatusMetadata(
+				new NotificationStatusMetadata(validationResult,
+						dispatchResult));
+		if (dispatchResult.successful()) {
+			notification.setNotificationStatus(DefaultNotificationStatus.SENT);
+			logger.debug(String.format("Notification %s sent successfully", notification.getId()));
+		} else {
+			notification.setNotificationStatus(DefaultNotificationStatus.INACTIVE);
+			logger.error(String.format("Notification %s failed to send: %s", notification.getId(),
+					dispatchResult.errorMessage()));
+		}
+		return notification;
+	}
+
+}

--- a/src/main/java/org/octri/notification/batch/TwilioStatusItemReader.java
+++ b/src/main/java/org/octri/notification/batch/TwilioStatusItemReader.java
@@ -1,0 +1,40 @@
+package org.octri.notification.batch;
+
+import java.util.Iterator;
+
+import org.octri.notification.domain.Notification;
+import org.octri.notification.repository.NotificationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.ItemReader;
+
+/**
+ * Determines the set of Notifications that need to be checked for final disposition in Twilio
+ */
+public class TwilioStatusItemReader implements ItemReader<Notification> {
+
+	private static final Logger log = LoggerFactory.getLogger(TwilioStatusItemReader.class);
+
+	private final NotificationRepository notificationRepository;
+	private Iterator<Notification> iterator;
+
+	/**
+	 * 
+	 * @param notificationRepository
+	 *            the Notification repository
+	 */
+	public TwilioStatusItemReader(NotificationRepository notificationRepository) {
+		this.notificationRepository = notificationRepository;
+	}
+
+	@Override
+	public Notification read() {
+		var queuedNotifications = notificationRepository.findAllQueuedTwilioNotifications();
+		log.debug("Updating status for {} queued Twilio notifications.", queuedNotifications.size());
+		if (iterator == null) {
+			iterator = queuedNotifications.iterator();
+		}
+		return iterator.hasNext() ? iterator.next() : null;
+	}
+
+}

--- a/src/main/java/org/octri/notification/batch/TwilioStatusItemWriter.java
+++ b/src/main/java/org/octri/notification/batch/TwilioStatusItemWriter.java
@@ -1,0 +1,68 @@
+package org.octri.notification.batch;
+
+import org.octri.messaging.sms.TwilioHelper;
+import org.octri.notification.domain.DefaultNotificationStatus;
+import org.octri.notification.domain.DispatchResult;
+import org.octri.notification.domain.Notification;
+import org.octri.notification.domain.Notification.NotificationStatusMetadata;
+import org.octri.notification.repository.NotificationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.item.Chunk;
+import org.springframework.batch.item.ItemWriter;
+
+/**
+ * Checks the final disposition of the Notifications in Twilio and updates the Notification status
+ */
+public class TwilioStatusItemWriter implements ItemWriter<Notification> {
+
+	private static final Logger log = LoggerFactory.getLogger(TwilioStatusItemWriter.class);
+
+	private final NotificationRepository notificationRepository;
+	private final TwilioHelper twilioHelper;
+
+	/**
+	 * 
+	 * @param notificationRepository
+	 *            the Notification repository
+	 * @param twilioHelper
+	 *            the helper for Twilio
+	 */
+	public TwilioStatusItemWriter(NotificationRepository notificationRepository, TwilioHelper twilioHelper) {
+		this.notificationRepository = notificationRepository;
+		this.twilioHelper = twilioHelper;
+	}
+
+	@Override
+	public void write(Chunk<? extends Notification> chunk) throws Exception {
+		for (Notification notification : chunk) {
+			var statusMetadata = notification.getStatusMetadata();
+			var dispatchResult = statusMetadata.dispatchResult();
+			var messageJson = dispatchResult.deliveryDetails();
+
+			var oldState = twilioHelper.loadMessageFromString(messageJson);
+			var messageSid = oldState.getSid();
+
+			log.debug("Getting updated status for message {}", messageSid);
+			var updatedState = twilioHelper.fetchMessage(messageSid);
+
+			log.debug("Old status: {} current status: {}", oldState.getStatus(), updatedState.getStatus());
+			if (!oldState.getStatus().equals(updatedState.getStatus())) {
+				if (!twilioHelper.isSuccessResponse(updatedState)) {
+					notification.setNotificationStatus(DefaultNotificationStatus.INACTIVE);
+				}
+
+				var updatedDeliveryDetails = twilioHelper.serializeMessageToJson(updatedState);
+				var updatedDispatchResult = new DispatchResult(twilioHelper.isSuccessResponse(updatedState),
+						dispatchResult.messageContent(), dispatchResult.recipient(), updatedDeliveryDetails,
+						updatedState.getErrorMessage() != null ? updatedState.getErrorMessage() : null);
+				var updatedStatusMetadata = new NotificationStatusMetadata(
+						statusMetadata.validationResult(), updatedDispatchResult);
+				notification.setNotificationStatusMetadata(updatedStatusMetadata);
+			}
+
+			notificationRepository.save(notification);
+		}
+	}
+
+}

--- a/src/main/java/org/octri/notification/batch/TwilioStatusUpdateJob.java
+++ b/src/main/java/org/octri/notification/batch/TwilioStatusUpdateJob.java
@@ -1,0 +1,68 @@
+package org.octri.notification.batch;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.configuration.DuplicateJobException;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+
+/**
+ * The job responsible for checking Twilio for the final disposition of Notifications
+ */
+public class TwilioStatusUpdateJob {
+
+	/**
+	 * Name of the job
+	 */
+	public static final String TWILIO_UPDATE_JOB_NAME = "twilioUpdateJob";
+
+	private final JobExplorer jobExplorer;
+	private final JobLauncher jobLauncher;
+	private final Job twilioUpdateJob;
+
+	/**
+	 * 
+	 * @param jobExplorer
+	 *            the job explorer
+	 * @param jobLauncher
+	 *            the job launcher
+	 * @param twilioUpdateJob
+	 *            the job for checking Twilio
+	 */
+	public TwilioStatusUpdateJob(JobExplorer jobExplorer, JobLauncher jobLauncher, Job twilioUpdateJob) {
+		this.jobExplorer = jobExplorer;
+		this.jobLauncher = jobLauncher;
+		this.twilioUpdateJob = twilioUpdateJob;
+	}
+
+	/**
+	 * Runs the job on demand
+	 * 
+	 * @throws Exception
+	 *             thrown by the JobLauncher
+	 */
+	public void runTwilioUpdateJob() throws Exception {
+		if (isJobRunning()) {
+			throw new DuplicateJobException("The Twilio update job is already running.");
+		}
+		var jobParameters = new JobParametersBuilder().addLong("time", System.currentTimeMillis()).toJobParameters();
+		jobLauncher.run(twilioUpdateJob, jobParameters);
+	}
+
+	/**
+	 * Runs the job on the cron schedule
+	 * 
+	 * @throws Exception
+	 *             thrown by the JobLauncher
+	 */
+	@Scheduled(cron = "${octri.notifications.twilio-update-schedule:@yearly}")
+	public void runScheduledTwilioUpdateJob() throws Exception {
+		runTwilioUpdateJob();
+	}
+
+	private boolean isJobRunning() {
+		return jobExplorer.findRunningJobExecutions(TWILIO_UPDATE_JOB_NAME).size() > 0;
+	}
+
+}

--- a/src/main/java/org/octri/notification/config/NotificationBatchConfig.java
+++ b/src/main/java/org/octri/notification/config/NotificationBatchConfig.java
@@ -1,0 +1,122 @@
+package org.octri.notification.config;
+
+import org.octri.common.customizer.IdentifiableEntityFinder;
+import org.octri.notification.batch.NotificationItemProcessor;
+import org.octri.notification.batch.NotificationItemReader;
+import org.octri.notification.batch.NotificationItemWriter;
+import org.octri.notification.domain.Notification;
+import org.octri.notification.domain.ProcessingMode;
+import org.octri.notification.registry.NotificationTypeRegistry;
+import org.octri.notification.repository.NotificationRepository;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Configuration for the Notification batch job
+ */
+@Configuration
+public class NotificationBatchConfig {
+
+	private final JobRepository jobRepository;
+	private final PlatformTransactionManager transactionManager;
+	private final NotificationRepository notificationRepository;
+	private final NotificationConfig notificationConfig;
+	private final NotificationTypeRegistry notificationTypeRegistry;
+	private final IdentifiableEntityFinder<?> recipientFinder;
+
+	/**
+	 * 
+	 * @param jobRepository
+	 *            the job repository
+	 * @param transactionManager
+	 *            the transaction manager
+	 * @param notificationRepository
+	 *            the notification repository
+	 * @param notificationConfig
+	 *            the notification configuration
+	 * @param notificationTypeRegistry
+	 *            the registry for notification types
+	 * @param recipientFinder
+	 *            the finder for recipients
+	 */
+	public NotificationBatchConfig(JobRepository jobRepository, PlatformTransactionManager transactionManager,
+			NotificationRepository notificationRepository, NotificationConfig notificationConfig,
+			NotificationTypeRegistry notificationTypeRegistry, IdentifiableEntityFinder<?> recipientFinder) {
+		this.jobRepository = jobRepository;
+		this.transactionManager = transactionManager;
+		this.notificationRepository = notificationRepository;
+		this.notificationConfig = notificationConfig;
+		this.notificationTypeRegistry = notificationTypeRegistry;
+		this.recipientFinder = recipientFinder;
+	}
+
+	/**
+	 * 
+	 * @param notificationItemReader
+	 *            the ItemReader for notifications
+	 * @return the notification job bean
+	 */
+	@Bean
+	public Job notificationJob(ItemReader<Notification> notificationItemReader) {
+		return new JobBuilder("notificationJob", jobRepository)
+				.incrementer(new RunIdIncrementer())
+				.start(processNotificationsStep(notificationItemReader))
+				.build();
+	}
+
+	/**
+	 * The scope ensures a new reader for each JobExecution and allows jobParameters to be injected
+	 * 
+	 * @param processingMode
+	 *            the processing mode provided by the job parameters
+	 * @return the notification item reader bean
+	 */
+	@Bean
+	@StepScope
+	public ItemReader<Notification> notificationItemReader(
+			@Value("#{jobParameters['processingMode']}") String processingMode) {
+		return new NotificationItemReader(notificationTypeRegistry, notificationRepository, recipientFinder,
+				ProcessingMode.valueOf(processingMode));
+	}
+
+	/**
+	 * 
+	 * @return the notification item processor bean
+	 */
+	@Bean
+	public ItemProcessor<Notification, Notification> notificationItemProcessor() {
+		return new NotificationItemProcessor(notificationTypeRegistry);
+	}
+
+	/**
+	 * 
+	 * @return the notification item writer bean
+	 */
+	@Bean
+	@JobScope
+	public ItemWriter<Notification> notificationItemWriter() {
+		return new NotificationItemWriter(notificationRepository, notificationTypeRegistry);
+	}
+
+	private Step processNotificationsStep(ItemReader<Notification> reader) {
+		return new StepBuilder("processNotificationsStep", jobRepository)
+				.<Notification, Notification> chunk(notificationConfig.getChunkSize(), transactionManager)
+				.reader(reader)
+				.processor(notificationItemProcessor())
+				.writer(notificationItemWriter())
+				.build();
+	}
+}

--- a/src/main/java/org/octri/notification/config/NotificationConfig.java
+++ b/src/main/java/org/octri/notification/config/NotificationConfig.java
@@ -1,0 +1,139 @@
+package org.octri.notification.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration properties for the notification system
+ */
+@Configuration
+@ConfigurationProperties(prefix = "octri.notifications")
+public class NotificationConfig {
+
+	private Boolean enabled;
+
+	private Integer chunkSize;
+
+	private String email;
+
+	private String smsNumber;
+
+	private String schedule;
+
+	private String twilioUpdateSchedule;
+
+	/**
+	 * A static getter for any custom logic relying on this flag in the application. This is available even if this bean
+	 * is never created.
+	 *
+	 * @return whether notifications are enabled
+	 */
+	public static boolean getNotificationsEnabled() {
+		String enabled = System.getProperty("octri.notifications.enabled",
+				System.getenv("OCTRI_NOTIFICATIONS_ENABLED"));
+		return "true".equalsIgnoreCase(enabled);
+	}
+
+	/**
+	 * 
+	 * @return whether notifications are enabled
+	 */
+	public Boolean getEnabled() {
+		return enabled;
+	}
+
+	/**
+	 * 
+	 * @param enabled
+	 *            whether notifications are enabled
+	 */
+	public void setEnabled(Boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	/**
+	 * 
+	 * @return the chunk size for processing
+	 */
+	public Integer getChunkSize() {
+		return chunkSize;
+	}
+
+	/**
+	 * 
+	 * @param chunkSize
+	 *            the chunk size for processing
+	 */
+	public void setChunkSize(Integer chunkSize) {
+		this.chunkSize = chunkSize;
+	}
+
+	/**
+	 * 
+	 * @return The email notifications will come from
+	 */
+	public String getEmail() {
+		return email;
+	}
+
+	/**
+	 * 
+	 * @param email
+	 *            The email notifications will come from
+	 */
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	/**
+	 * 
+	 * @return The number text notifications will come from
+	 */
+	public String getSmsNumber() {
+		return smsNumber;
+	}
+
+	/**
+	 * 
+	 * @param smsNumber
+	 *            The number text notifications will come from
+	 */
+	public void setSmsNumber(String smsNumber) {
+		this.smsNumber = smsNumber;
+	}
+
+	/**
+	 * 
+	 * @return The CRON schedule for the batch job that processes notifications
+	 */
+	public String getSchedule() {
+		return schedule;
+	}
+
+	/**
+	 * 
+	 * @param schedule
+	 *            The CRON schedule for the batch job that processes notifications
+	 */
+	public void setSchedule(String schedule) {
+		this.schedule = schedule;
+	}
+
+	/**
+	 * 
+	 * @return the CRON scheduled for the batch job that checks Twilio status
+	 */
+	public String getTwilioUpdateSchedule() {
+		return twilioUpdateSchedule;
+	}
+
+	/**
+	 * 
+	 * @param twilioUpdateSchedule
+	 *            the CRON scheduled for the batch job that checks Twilio status
+	 */
+	public void setTwilioUpdateSchedule(String twilioUpdateSchedule) {
+		this.twilioUpdateSchedule = twilioUpdateSchedule;
+	}
+
+}

--- a/src/main/java/org/octri/notification/config/TwilioStatusBatchConfig.java
+++ b/src/main/java/org/octri/notification/config/TwilioStatusBatchConfig.java
@@ -1,0 +1,135 @@
+package org.octri.notification.config;
+
+import org.octri.messaging.autoconfig.TwilioConfiguredCondition;
+import org.octri.messaging.sms.TwilioHelper;
+import org.octri.notification.batch.TwilioStatusItemReader;
+import org.octri.notification.batch.TwilioStatusItemWriter;
+import org.octri.notification.batch.TwilioStatusUpdateJob;
+import org.octri.notification.domain.Notification;
+import org.octri.notification.repository.NotificationRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.JobScope;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+/**
+ * Configuration for the batch job for checking Twilio status
+ */
+@Configuration
+@Conditional(TwilioConfiguredCondition.class)
+public class TwilioStatusBatchConfig {
+
+	private static final Logger log = LoggerFactory.getLogger(TwilioStatusBatchConfig.class);
+
+	private final JobRepository jobRepository;
+	private final JobExplorer jobExplorer;
+	private final JobLauncher jobLauncher;
+
+	private final PlatformTransactionManager transactionManager;
+
+	private final NotificationConfig notificationConfig;
+	private final NotificationRepository notificationRepository;
+
+	private final TwilioHelper twilioHelper;
+
+	/**
+	 * 
+	 * @param jobRepository
+	 *            the JobRepository
+	 * @param jobExplorer
+	 *            the JobExplorer
+	 * @param jobLauncher
+	 *            the JobLauncher
+	 * @param transactionManager
+	 *            the PlatformTransactionManager
+	 * @param notificationConfig
+	 *            the NotificationConfig
+	 * @param notificationRepository
+	 *            the NotificationRepository
+	 * @param twilioHelper
+	 *            the TwilioHelper
+	 */
+	public TwilioStatusBatchConfig(JobRepository jobRepository, JobExplorer jobExplorer, JobLauncher jobLauncher,
+			PlatformTransactionManager transactionManager,
+			NotificationConfig notificationConfig, NotificationRepository notificationRepository,
+			TwilioHelper twilioHelper) {
+		log.debug("Creating Twilio update job beans");
+		this.jobRepository = jobRepository;
+		this.jobExplorer = jobExplorer;
+		this.jobLauncher = jobLauncher;
+		this.transactionManager = transactionManager;
+		this.notificationConfig = notificationConfig;
+		this.notificationRepository = notificationRepository;
+		this.twilioHelper = twilioHelper;
+	}
+
+	/**
+	 * 
+	 * @return the ItemReader bean for the TwilioStatusUpdateJob
+	 */
+	@Bean
+	@StepScope
+	public ItemReader<Notification> twilioStatusItemReader() {
+		return new TwilioStatusItemReader(notificationRepository);
+	}
+
+	/**
+	 * 
+	 * @return the ItemWriter bean for the TwilioStatusUpdateJob
+	 */
+	@Bean
+	@JobScope
+	public ItemWriter<Notification> twilioStatusItemWriter() {
+		return new TwilioStatusItemWriter(notificationRepository, twilioHelper);
+	}
+
+	/**
+	 * 
+	 * @param jobLauncher
+	 *            the JobLauncher
+	 * @param twilioStatusItemReader
+	 *            the item reader
+	 * @return the bean for the Job
+	 */
+	@Bean
+	public Job twilioUpdateJob(JobLauncher jobLauncher, ItemReader<Notification> twilioStatusItemReader) {
+		return new JobBuilder(TwilioStatusUpdateJob.TWILIO_UPDATE_JOB_NAME, jobRepository)
+				.incrementer(new RunIdIncrementer())
+				.start(twilioUpdateStep(twilioStatusItemReader))
+				.build();
+	}
+
+	/**
+	 * 
+	 * @param twilioUpdateJob
+	 *            the Job
+	 * @return the Bean for the TwilioStatusUpdateJob
+	 */
+	@Bean
+	public TwilioStatusUpdateJob twilioStatusUpdateJob(Job twilioUpdateJob) {
+		return new TwilioStatusUpdateJob(jobExplorer, jobLauncher, twilioUpdateJob);
+	}
+
+	private Step twilioUpdateStep(ItemReader<Notification> reader) {
+		return new StepBuilder("processTwilioNotificationsStep", jobRepository)
+				.<Notification, Notification> chunk(notificationConfig.getChunkSize(), transactionManager)
+				.reader(reader)
+				.writer(twilioStatusItemWriter())
+				.build();
+	}
+
+}

--- a/src/main/java/org/octri/notification/controller/NotificationController.java
+++ b/src/main/java/org/octri/notification/controller/NotificationController.java
@@ -1,0 +1,160 @@
+package org.octri.notification.controller;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.octri.common.controller.AbstractEntityController;
+import org.octri.common.customizer.IdentifiableEntityFinder;
+import org.octri.common.view.IdentifiableOptionList;
+import org.octri.common.view.OptionList;
+import org.octri.common.view.ViewUtils;
+import org.octri.notification.domain.Notification;
+import org.octri.notification.registry.NotificationStatusRegistry;
+import org.octri.notification.registry.NotificationTypeRegistry;
+import org.octri.notification.repository.NotificationRepository;
+import org.octri.notification.view.NotificationStatusSelectOption;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+/**
+ * Controller for {@link Notification} objects.
+ */
+@Controller
+@RequestMapping("/admin/notification")
+public class NotificationController extends AbstractEntityController<Notification, NotificationRepository> {
+
+	private final NotificationRepository repository;
+	private final IdentifiableEntityFinder<?> recipientFinder;
+	private final NotificationTypeRegistry notificationTypeRegistry;
+	private final NotificationStatusRegistry notificationStatusRegistry;
+
+	/**
+	 * 
+	 * @param repository
+	 *            the notification repository
+	 * @param recipientFinder
+	 *            the finder for recipients
+	 * @param notificationTypeRegistry
+	 *            the registration for notification types
+	 * @param notificationStatusRegistry
+	 *            the registry for notification statuses
+	 */
+	public NotificationController(NotificationRepository repository, IdentifiableEntityFinder<?> recipientFinder,
+			NotificationTypeRegistry notificationTypeRegistry, NotificationStatusRegistry notificationStatusRegistry) {
+		this.repository = repository;
+		this.recipientFinder = recipientFinder;
+		this.notificationTypeRegistry = notificationTypeRegistry;
+		this.notificationStatusRegistry = notificationStatusRegistry;
+	}
+
+	@GetMapping("/")
+	@Override
+	public String list(Map<String, Object> model) {
+		var template = super.list(model);
+		@SuppressWarnings("unchecked")
+		Iterable<Notification> notifications = (Iterable<Notification>) model.get("entity_list");
+		List<Notification> notificationViews = StreamSupport
+				.stream(notifications.spliterator(), false)
+				.map(n -> {
+					var handler = notificationTypeRegistry.getHandler(n.getNotificationType());
+					if (handler != null) {
+						n.setNotificationRecipientView(handler.getViewer().getRecipientView(n));
+						n.setNotificationMetadataView(handler.getViewer().getMetadataView(n));
+					}
+					return n;
+				}).collect(Collectors.toList());
+		model.put("entity_list", notificationViews);
+		model.put("notificationStatuses", notificationStatusRegistry.getStatuses());
+		ViewUtils.addPageScript(model, "table-filtering.js");
+
+		return template;
+	}
+
+	@GetMapping("/{id}")
+	@Override
+	public String show(Map<String, Object> model, @PathVariable Long id) {
+		var template = super.show(model, id);
+		Notification notification = (Notification) model.get("entity");
+		var handler = notificationTypeRegistry.getHandler(notification.getNotificationType());
+		if (handler != null) {
+			notification.setNotificationRecipientView(handler.getViewer().getRecipientView(notification));
+			notification.setNotificationMetadataView(handler.getViewer().getMetadataView(notification));
+		}
+		model.put("editingEnabled", model.get("isSuper"));
+		ViewUtils.addPageScript(model, "vendor.js");
+		ViewUtils.addPageScript(model, "delivery-details.js");
+		return template;
+	}
+
+	@Override
+	@PreAuthorize("hasRole('ROLE_SUPER')")
+	public String newEntity(Map<String, Object> model) {
+		String template = super.newEntity(model);
+
+		// Add options for select.
+		model.put("recipientOptions",
+				IdentifiableOptionList.fromAll(recipientFinder, null));
+		model.put("notificationStatusOptions",
+				NotificationStatusSelectOption.fromStatuses(notificationStatusRegistry.getStatuses(),
+						null));
+		model.put("notificationTypeOptions",
+				OptionList.forStrings(new ArrayList<String>(notificationTypeRegistry.getRegisteredTypes()), null));
+		return template;
+	}
+
+	@Override
+	@PreAuthorize("hasRole('ROLE_SUPER')")
+	public String edit(Map<String, Object> model, @PathVariable Long id) {
+		String template = super.edit(model, id);
+
+		Notification entity = (Notification) model.get("entity");
+
+		// Add options for select.
+		model.put("recipientOptions",
+				IdentifiableOptionList.fromAll(recipientFinder, entity.getRecipientUuid()));
+		model.put("notificationStatusOptions",
+				NotificationStatusSelectOption.fromStatuses(notificationStatusRegistry.getStatuses(),
+						entity.getNotificationStatus()));
+		model.put("notificationTypeOptions",
+				OptionList.forStrings(new ArrayList<String>(notificationTypeRegistry.getRegisteredTypes()),
+						entity.getNotificationType()));
+
+		return template;
+	}
+
+	@Override
+	@PreAuthorize("hasRole('ROLE_SUPER')")
+	public String create(Map<String, Object> model, @ModelAttribute("entity") Notification entity,
+			BindingResult bindingResult,
+			RedirectAttributes redirectAttributes) {
+		return super.create(model, entity, bindingResult, redirectAttributes);
+	}
+
+	@Override
+	@PreAuthorize("hasRole('ROLE_SUPER')")
+	public String update(Map<String, Object> model, @PathVariable Long id,
+			@ModelAttribute("entity") Notification entity,
+			BindingResult bindingResult,
+			RedirectAttributes redirectAttributes) {
+		return super.update(model, id, entity, bindingResult, redirectAttributes);
+	}
+
+	@Override
+	protected Class<Notification> domainClass() {
+		return Notification.class;
+	}
+
+	@Override
+	protected NotificationRepository getRepository() {
+		return this.repository;
+	}
+}

--- a/src/main/java/org/octri/notification/converter/NotificationStatusMvcConverter.java
+++ b/src/main/java/org/octri/notification/converter/NotificationStatusMvcConverter.java
@@ -1,0 +1,29 @@
+package org.octri.notification.converter;
+
+import org.octri.notification.domain.NotificationStatus;
+import org.octri.notification.registry.NotificationStatusRegistry;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+/**
+ * This allows Spring MVC to convert the String in the form to a NotificationStatus for persistence
+ */
+@Component
+public class NotificationStatusMvcConverter implements Converter<String, NotificationStatus> {
+
+	private final NotificationStatusRegistry notificationStatusRegistry;
+
+	/**
+	 * 
+	 * @param notificationStatusRegistry
+	 *            the registry for notification statuses
+	 */
+	public NotificationStatusMvcConverter(NotificationStatusRegistry notificationStatusRegistry) {
+		this.notificationStatusRegistry = notificationStatusRegistry;
+	}
+
+	@Override
+	public NotificationStatus convert(String status) {
+		return notificationStatusRegistry.getStatusByName(status).orElseThrow();
+	}
+}

--- a/src/main/java/org/octri/notification/converter/NotificationStatusPersistenceConverter.java
+++ b/src/main/java/org/octri/notification/converter/NotificationStatusPersistenceConverter.java
@@ -1,0 +1,38 @@
+package org.octri.notification.converter;
+
+import org.octri.notification.domain.NotificationStatus;
+import org.octri.notification.registry.NotificationStatusRegistry;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * This Converter tells Hibernate how to serialize/deserialize NotificationStatus from the persistence layer
+ */
+@Converter(autoApply = true)
+public class NotificationStatusPersistenceConverter implements AttributeConverter<NotificationStatus, String> {
+
+	private final NotificationStatusRegistry notificationStatusRegistry;
+
+	/**
+	 * 
+	 * @param notificationStatusRegistry
+	 *            the registry for notification statuses
+	 */
+	public NotificationStatusPersistenceConverter(NotificationStatusRegistry notificationStatusRegistry) {
+		this.notificationStatusRegistry = notificationStatusRegistry;
+	}
+
+	@Override
+	public String convertToDatabaseColumn(NotificationStatus status) {
+		return (status == null) ? null : status.name();
+	}
+
+	@Override
+	public NotificationStatus convertToEntityAttribute(String dbData) {
+		if (dbData == null) {
+			return null;
+		}
+		return notificationStatusRegistry.getStatusByName(dbData).orElseThrow();
+	}
+}

--- a/src/main/java/org/octri/notification/dispatch/AbstractNotificationDispatcher.java
+++ b/src/main/java/org/octri/notification/dispatch/AbstractNotificationDispatcher.java
@@ -1,0 +1,120 @@
+package org.octri.notification.dispatch;
+
+import java.util.Map;
+
+import org.octri.messaging.exception.UnsuccessfulDeliveryException;
+import org.octri.messaging.service.MessageDeliveryService;
+import org.octri.notification.config.NotificationConfig;
+import org.octri.notification.domain.DispatchResult;
+
+import com.samskivert.mustache.Mustache;
+
+/**
+ * Abstract base class for notification dispatchers providing common functionality
+ */
+public abstract class AbstractNotificationDispatcher implements NotificationDispatcher {
+
+	private final MessageDeliveryService messageDeliveryService;
+	private final NotificationConfig notificationConfig;
+	private final Mustache.Compiler mustacheCompiler;
+
+	/**
+	 * Constructor
+	 * 
+	 * @param messageDeliveryService
+	 *            service for delivering messages
+	 * @param notificationConfig
+	 *            configuration for notifications
+	 * @param mustacheCompiler
+	 *            Mustache compiler for templating
+	 */
+	public AbstractNotificationDispatcher(MessageDeliveryService messageDeliveryService,
+			NotificationConfig notificationConfig, Mustache.Compiler mustacheCompiler) {
+		this.messageDeliveryService = messageDeliveryService;
+		this.notificationConfig = notificationConfig;
+		this.mustacheCompiler = mustacheCompiler;
+	}
+
+	/**
+	 * Generate message content by applying the given values to the provided template
+	 * 
+	 * @param template
+	 *            the message template
+	 * @param values
+	 *            the values to apply to the template
+	 * @return the generated message content
+	 */
+	public String generateMessageContent(String template, Map<String, String> values) {
+		return mustacheCompiler.compile(template).execute(values);
+	}
+
+	/**
+	 * Send an email
+	 * 
+	 * @param recipient
+	 *            the recipient email address
+	 * @param subject
+	 *            the subject line of the email
+	 * @param messageContent
+	 *            the body content of the email
+	 * @return the result of the dispatch attempt
+	 */
+	public DispatchResult sendEmail(String recipient, String subject, String messageContent) {
+		try {
+			var deliveryDetails = messageDeliveryService.sendEmail(notificationConfig.getEmail(), recipient, subject,
+					messageContent);
+			return new DispatchResult(true, messageContent, recipient,
+					deliveryDetails.isPresent() ? deliveryDetails.get() : null, null);
+		} catch (UnsuccessfulDeliveryException e) {
+			return new DispatchResult(false, messageContent, recipient, null, e.getErrorResponse());
+		}
+	}
+
+	/**
+	 * Send an SMS
+	 * 
+	 * @param recipient
+	 *            the recipient phone number
+	 * @param messageContent
+	 *            the SMS message content
+	 * @return the result of the dispatch attempt
+	 */
+	public DispatchResult sendSms(String recipient, String messageContent) {
+		try {
+			var deliveryDetails = messageDeliveryService.sendSms(notificationConfig.getSmsNumber(), recipient,
+					messageContent);
+			return new DispatchResult(true, messageContent, recipient,
+					deliveryDetails.isPresent() ? deliveryDetails.get() : null, null);
+		} catch (UnsuccessfulDeliveryException e) {
+			return new DispatchResult(false, messageContent, recipient, null, e.getErrorResponse());
+		}
+	}
+
+	/**
+	 * Get the message delivery service
+	 * 
+	 * @return the message delivery service
+	 */
+	public MessageDeliveryService getMessageDeliveryService() {
+		return messageDeliveryService;
+	}
+
+	/**
+	 * Get the notification configuration
+	 * 
+	 * @return the notification configuration
+	 */
+	public NotificationConfig getNotificationConfig() {
+		return notificationConfig;
+	}
+
+	/**
+	 * Get the Mustache compiler
+	 * 
+	 * @return the Mustache compiler
+	 */
+	public Mustache.Compiler getMustacheCompiler() {
+		return mustacheCompiler;
+	}
+
+}

--- a/src/main/java/org/octri/notification/dispatch/NotificationDispatcher.java
+++ b/src/main/java/org/octri/notification/dispatch/NotificationDispatcher.java
@@ -1,0 +1,19 @@
+package org.octri.notification.dispatch;
+
+import org.octri.notification.domain.DispatchResult;
+import org.octri.notification.domain.Notification;
+
+/**
+ * Interface for a component that can dispatch a Notification of the NotificationType provided.
+ */
+public interface NotificationDispatcher {
+
+	/**
+	 * 
+	 * @param notification
+	 *            the notification to dispatch
+	 * @return the DispatchResult
+	 */
+	public DispatchResult handleDispatch(Notification notification);
+
+}

--- a/src/main/java/org/octri/notification/domain/AbstractReminderDayProgressionTracker.java
+++ b/src/main/java/org/octri/notification/domain/AbstractReminderDayProgressionTracker.java
@@ -1,0 +1,61 @@
+package org.octri.notification.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.octri.notification.metadata.NotificationMetadata;
+
+/**
+ * An implementation of a {@link ReminderDayProgressionTracker} and {@link NotificationMetadata} to be used when you
+ * want to configure the batch job to create the next {@link Notification} in the series at the time the first
+ * Notification is processed. Create this object once with the set of reminder days and the initial index of 0, and
+ * persist a Notification with this metadata. The batch job will create subsequent Notifications with the same
+ * characteristics, advancing the scheduled date to the next in the series.
+ */
+public abstract class AbstractReminderDayProgressionTracker
+		implements ReminderDayProgressionTracker, NotificationMetadata {
+
+	private List<Integer> reminderDays;
+	private int currentIndex;
+	private LocalDate startDate;
+
+	/**
+	 * Default constructor for serialization.
+	 */
+	public AbstractReminderDayProgressionTracker() {
+
+	}
+
+	/**
+	 * 
+	 * @param startDate
+	 *            the date from which to calculate subsequent reminder days
+	 * @param reminderDays
+	 *            the series of days on which to send reminders, relative to the start date
+	 */
+	public AbstractReminderDayProgressionTracker(LocalDate startDate, List<Integer> reminderDays) {
+		this.startDate = startDate;
+		this.reminderDays = reminderDays;
+		this.currentIndex = 0;
+	}
+
+	@Override
+	public LocalDate getStartDate() {
+		return startDate;
+	}
+
+	@Override
+	public List<Integer> getReminderDays() {
+		return reminderDays;
+	}
+
+	@Override
+	public int getCurrentIndex() {
+		return currentIndex;
+	}
+
+	@Override
+	public void setCurrentIndex(int index) {
+		this.currentIndex = index;
+	}
+}

--- a/src/main/java/org/octri/notification/domain/DefaultNotificationStatus.java
+++ b/src/main/java/org/octri/notification/domain/DefaultNotificationStatus.java
@@ -1,0 +1,39 @@
+package org.octri.notification.domain;
+
+/**
+ * The default implementation of NotificationStatus
+ */
+public enum DefaultNotificationStatus implements NotificationStatus {
+
+	/**
+	 * Notification is scheduled to be sent
+	 */
+	SCHEDULED("Scheduled", false),
+	/**
+	 * Notification was no longer valid or failed to send
+	 */
+	INACTIVE("Inactive", true),
+	/**
+	 * Notification was sent (but not necessarily delivered)
+	 */
+	SENT("Sent", true);
+
+	private final String label;
+	private final boolean descending;
+
+	DefaultNotificationStatus(String label, boolean descending) {
+		this.label = label;
+		this.descending = descending;
+	}
+
+	@Override
+	public String getLabel() {
+		return label;
+	}
+
+	@Override
+	public boolean descending() {
+		return descending;
+	}
+
+}

--- a/src/main/java/org/octri/notification/domain/DispatchResult.java
+++ b/src/main/java/org/octri/notification/domain/DispatchResult.java
@@ -1,0 +1,19 @@
+package org.octri.notification.domain;
+
+/**
+ * Record representing the result of a dispatch attempt
+ * 
+ * @param successful
+ *            whether the dispatch was successful
+ * @param messageContent
+ *            the content of the message that was attempted to be sent
+ * @param recipient
+ *            the recipient of the message
+ * @param deliveryDetails
+ *            details about the delivery
+ * @param errorMessage
+ *            error message if the dispatch failed
+ */
+public record DispatchResult(Boolean successful, String messageContent, String recipient, String deliveryDetails,
+		String errorMessage) {
+}

--- a/src/main/java/org/octri/notification/domain/Notification.java
+++ b/src/main/java/org/octri/notification/domain/Notification.java
@@ -1,0 +1,407 @@
+package org.octri.notification.domain;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.octri.common.domain.AbstractEntity;
+import org.octri.notification.metadata.NotificationMetadata;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Transient;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * Entity representing a notification to a {@link Recipient}
+ */
+@Entity
+public class Notification extends AbstractEntity {
+
+	/**
+	 * Record representing the status metadata of a notification
+	 * 
+	 * @param validationResult
+	 *            the result of the validation step
+	 * @param dispatchResult
+	 *            the result of the dispatch step
+	 */
+	public record NotificationStatusMetadata(ValidationResult validationResult,
+			DispatchResult dispatchResult) {
+
+	}
+
+	/**
+	 * Date the notification is scheduled for
+	 */
+	@NotNull
+	private LocalDate dateScheduled;
+
+	/**
+	 * UUID of recipient to be notified
+	 */
+	@NotNull
+	private String recipientUuid;
+
+	/**
+	 * Status of the notification
+	 */
+	@NotNull
+	private NotificationStatus notificationStatus;
+
+	/**
+	 * Type of notification
+	 */
+	@NotNull
+	private String notificationType;
+
+	/**
+	 * Metadata about the notification to be used for validation and dispatch
+	 */
+	@Column(columnDefinition = "JSON")
+	private String notificationMetadata;
+
+	/**
+	 * Date and time the notification was processed
+	 */
+	private LocalDateTime dateTimeProcessed;
+
+	/**
+	 * Metadata about the disposition of the notification
+	 */
+	@Column(columnDefinition = "JSON")
+	private String notificationStatusMetadata;
+
+	/**
+	 * Custom ObjectMapper for serializing/deserializing metadata
+	 */
+	@Transient
+	private ObjectMapper mapper = new ObjectMapper();
+
+	/**
+	 * The recipient entity. The caller must ensure this is set along with the recipientUuid
+	 */
+	@Transient
+	private Recipient recipient;
+
+	/**
+	 * User-friendly view of the {@link Recipient}. Populated by the NotificationViewer for display purposes only
+	 */
+	@Transient
+	private String notificationRecipientView;
+	/**
+	 * User-friendly view of the {@link NotificationMetadata}. Populated by the NotificationViewer for display purposes
+	 * only
+	 */
+	@Transient
+	private String notificationMetadataView;
+
+	/**
+	 * Create an empty Notification
+	 */
+	public Notification() {
+		this.configureMapper();
+	}
+
+	/**
+	 * Create a Notification for a uniquely identified entity (ex. Participant)
+	 *
+	 * @param relatedEntity
+	 *            the recipient entity
+	 */
+	public Notification(Recipient relatedEntity) {
+		this.configureMapper();
+		this.setRecipient(relatedEntity);
+	}
+
+	private void configureMapper() {
+		// Adds support for LocalDate
+		mapper.registerModule(new JavaTimeModule());
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		// This ensures that an empty NotificationMetadata can be serialized
+		mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
+		// This ensures unnecessary fields aren't serialized/deserialized if the ReminderDayProgressionTracker is used
+		mapper.addMixIn(ReminderDayProgressionTracker.class, ProgressionTrackerMixin.class);
+	}
+
+	/**
+	 * @return the scheduled date
+	 */
+	public LocalDate getDateScheduled() {
+		return dateScheduled;
+	}
+
+	/**
+	 * 
+	 * @param dateScheduled
+	 *            the scheduled date
+	 */
+	public void setDateScheduled(LocalDate dateScheduled) {
+		this.dateScheduled = dateScheduled;
+	}
+
+	/**
+	 * 
+	 * @return the UUID of the recipient to be notified
+	 */
+	public String getRecipientUuid() {
+		return recipientUuid;
+	}
+
+	/**
+	 * 
+	 * @param uuid
+	 *            the UUID of the recipient to be notified
+	 */
+	public void setRecipientUuid(String uuid) {
+		// Ensure that convenience of transient entity does not get out of sync with uuid.
+		// We can't update the entity since there is no guarantee of a setter.
+		if (this.recipient != null) {
+			this.recipient = null;
+		}
+		this.recipientUuid = uuid;
+	}
+
+	/**
+	 * 
+	 * @return the status of the notification
+	 */
+	public NotificationStatus getNotificationStatus() {
+		return notificationStatus;
+	}
+
+	/**
+	 * 
+	 * @param notificationStatus
+	 *            the status of the notification
+	 */
+	public void setNotificationStatus(NotificationStatus notificationStatus) {
+		this.notificationStatus = notificationStatus;
+	}
+
+	/**
+	 * 
+	 * @return the notification type
+	 */
+	public String getNotificationType() {
+		return notificationType;
+	}
+
+	/**
+	 * 
+	 * @param notificationType
+	 *            the notification type
+	 */
+	public void setNotificationType(String notificationType) {
+		this.notificationType = notificationType;
+	}
+
+	/**
+	 * 
+	 * @return the notification metadata as a JSON string
+	 */
+	public String getNotificationMetadata() {
+		return notificationMetadata;
+	}
+
+	/**
+	 * 
+	 * @param notificationMetadata
+	 *            the notification metadata as a JSON string
+	 */
+	public void setNotificationMetadata(String notificationMetadata) {
+		this.notificationMetadata = notificationMetadata;
+	}
+
+	/**
+	 * 
+	 * @param notificationMetadata
+	 *            the notification metadata object
+	 */
+	public void setNotificationMetadata(NotificationMetadata notificationMetadata) {
+		try {
+			this.notificationMetadata = mapper.writeValueAsString(notificationMetadata);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException("Failed to serialize metadata", e);
+		}
+	}
+
+	/**
+	 * Deserialize the notification metadata into the specified class
+	 * 
+	 * @param <T>
+	 *            the type of the metadata
+	 * @param metadataClass
+	 *            the class to deserialize into
+	 * @return the deserialized metadata
+	 */
+	public <T extends NotificationMetadata> T getNotificationMetadata(Class<T> metadataClass) {
+		if (notificationMetadata == null) {
+			throw new IllegalStateException("Notification metadata is null");
+		}
+		try {
+			return mapper.readValue(notificationMetadata, metadataClass);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to deserialize metadata", e);
+		}
+	}
+
+	/**
+	 * 
+	 * @return the date and time the notification was processed
+	 */
+	public LocalDateTime getDateTimeProcessed() {
+		return dateTimeProcessed;
+	}
+
+	/**
+	 * 
+	 * @param dateTimeProcessed
+	 *            the date and time the notification was processed
+	 */
+	public void setDateTimeProcessed(LocalDateTime dateTimeProcessed) {
+		this.dateTimeProcessed = dateTimeProcessed;
+	}
+
+	/**
+	 * 
+	 * @return the notification status metadata as a JSON string
+	 */
+	public String getNotificationStatusMetadata() {
+		return notificationStatusMetadata;
+	}
+
+	/**
+	 * 
+	 * @param notificationStatusMetadata
+	 *            the notification status metadata as an object
+	 */
+	public void setNotificationStatusMetadata(String notificationStatusMetadata) {
+		this.notificationStatusMetadata = notificationStatusMetadata;
+	}
+
+	/**
+	 * 
+	 * @param notificationStatusMetadataRecord
+	 *            the notification status metadata record
+	 */
+	public void setNotificationStatusMetadata(NotificationStatusMetadata notificationStatusMetadataRecord) {
+		try {
+			this.notificationStatusMetadata = mapper.writeValueAsString(notificationStatusMetadataRecord);
+		} catch (JsonProcessingException e) {
+			throw new RuntimeException(
+					"Failed to serialize status metadata", e);
+		}
+	}
+
+	/**
+	 * 
+	 * @return the deserialized notification status metadata
+	 */
+	public NotificationStatusMetadata getStatusMetadata() {
+		if (notificationStatusMetadata == null) {
+			return null;
+		}
+		try {
+			return mapper.readValue(notificationStatusMetadata, NotificationStatusMetadata.class);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to deserialize status metadata", e);
+		}
+	}
+
+	/**
+	 * 
+	 * @return the scheduled date in ISO format
+	 */
+	public String dateScheduledIso() {
+		return getDateScheduled().format(DateTimeFormatter.ISO_DATE);
+	}
+
+	/**
+	 * 
+	 * @return a user-friendly view of the recipient
+	 */
+	public String getNotificationRecipientView() {
+		return notificationRecipientView;
+	}
+
+	/**
+	 * 
+	 * @param notificationRecipientView
+	 *            a user-friendly view of the recipient
+	 */
+	public void setNotificationRecipientView(String notificationRecipientView) {
+		this.notificationRecipientView = notificationRecipientView;
+	}
+
+	/**
+	 * @return a user-friendly view of the notification metadata
+	 */
+	public String getNotificationMetadataView() {
+		return notificationMetadataView;
+	}
+
+	/**
+	 * @param notificationMetadataView
+	 *            a user-friendly view of the notification metadata
+	 */
+	public void setNotificationMetadataView(String notificationMetadataView) {
+		this.notificationMetadataView = notificationMetadataView;
+	}
+
+	/**
+	 * The caller must ensure this is set along with the recipientUuid
+	 * 
+	 * @return the recipient entity
+	 */
+	public Recipient getRecipient() {
+		return recipient;
+	}
+
+	/**
+	 * 
+	 * @param entity
+	 *            the recipient of the notification
+	 */
+	public void setRecipient(Recipient entity) {
+		if (entity == null) {
+			this.setRecipientUuid(null);
+		} else {
+			// Prevent mismatch when loading entity from the database.
+			if (recipient == null && recipientUuid != null && !entity.getUuid().equals(recipientUuid)) {
+				throw new IllegalArgumentException("UUID of provided entity must match the current uuid value.");
+			}
+			this.setRecipientUuid(entity.getUuid());
+		}
+		this.recipient = entity;
+	}
+
+	/**
+	 * 
+	 * @return A unique key used by the dispatch process to prevent sending duplicates
+	 */
+	public String getDispatchKey() {
+		return String.join(this.getNotificationType(), String.valueOf(this.getRecipientUuid()),
+				this.getDateScheduled().toString(), this.getNotificationMetadata(), "-");
+	}
+
+	/**
+	 * 
+	 * @return The JSON ObjectMapper to use for parsing NotificationMetadata and NotificationStatusMetadata
+	 */
+	public ObjectMapper getObjectMapper() {
+		return mapper;
+	}
+
+	@Override
+	public String toString() {
+		return "Notification [dateScheduled=" + dateScheduled + ", recipientUuid=" + recipientUuid
+				+ ", notificationStatus=" + notificationStatus + ", notificationType=" + notificationType + "]";
+	}
+
+}

--- a/src/main/java/org/octri/notification/domain/NotificationStatus.java
+++ b/src/main/java/org/octri/notification/domain/NotificationStatus.java
@@ -1,0 +1,35 @@
+package org.octri.notification.domain;
+
+import org.octri.common.view.Labelled;
+import org.octri.notification.batch.NotificationItemReader;
+import org.octri.notification.batch.NotificationItemWriter;
+import org.octri.notification.registry.NotificationStatusRegistry;
+
+/**
+ * The extensible interface defining the NotificationStatus of a Notification. Applications can use the
+ * {@link NotificationStatusRegistry} to add or remove statuses or override properties. This library expects a status
+ * with the name 'SCHEDULED' in the {@link NotificationItemReader} and statuses with the name 'SENT' and 'INACTIVE' in
+ * the {@link NotificationItemWriter}. These beans would need to be overridden if an application removes these status
+ * names. Additionally, the batch job that checks Twilio for the final disposition of a text uses the 'SENT' status in
+ * the NotificationRepository.
+ */
+public interface NotificationStatus extends Labelled {
+
+	/**
+	 * @return the unique, stable name of the status (used in DB, business logic)
+	 */
+	String name();
+
+	/**
+	 * 
+	 * @return the order of the status, used for tabbed filter display on the Notification list page
+	 */
+	int ordinal();
+
+	/**
+	 * 
+	 * @return whether the status should be displayed in descending order on the list page
+	 */
+	boolean descending();
+
+}

--- a/src/main/java/org/octri/notification/domain/ProcessingMode.java
+++ b/src/main/java/org/octri/notification/domain/ProcessingMode.java
@@ -1,0 +1,24 @@
+package org.octri.notification.domain;
+
+import org.octri.common.view.Labelled;
+
+/**
+ * The mode a Notification will be processed in - either scheduled or immediate.
+ */
+public enum ProcessingMode implements Labelled {
+
+	/**
+	 * Notification should be processed immediately after creation
+	 */
+	IMMEDIATE,
+	/**
+	 * Notification should be processed on a schedule
+	 */
+	SCHEDULED;
+
+	@Override
+	public String getLabel() {
+		return name();
+	}
+
+}

--- a/src/main/java/org/octri/notification/domain/ProgressionTrackerMixin.java
+++ b/src/main/java/org/octri/notification/domain/ProgressionTrackerMixin.java
@@ -1,0 +1,34 @@
+package org.octri.notification.domain;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Used to avoid unnecessary mapping of some ReminderDayProgressionTracker fields when persisting metadata to the
+ * database
+ */
+public abstract class ProgressionTrackerMixin {
+
+	/**
+	 * 
+	 * @return isFinal
+	 */
+	@JsonIgnore
+	public abstract boolean isFinal();
+
+	/**
+	 * 
+	 * @return currentDay
+	 */
+	@JsonIgnore
+	public abstract int getCurrentDay();
+
+	/**
+	 * 
+	 * @return currentDate
+	 */
+	@JsonIgnore
+	public abstract LocalDate getCurrentDate();
+
+}

--- a/src/main/java/org/octri/notification/domain/Recipient.java
+++ b/src/main/java/org/octri/notification/domain/Recipient.java
@@ -1,8 +1,9 @@
 package org.octri.notification.domain;
 
+import org.octri.common.domain.Identifiable;
+
 /**
  * Interface representing a recipient of notifications.
  */
-public interface Recipient {
-
+public interface Recipient extends Identifiable {
 }

--- a/src/main/java/org/octri/notification/domain/ReminderDayProgressionTracker.java
+++ b/src/main/java/org/octri/notification/domain/ReminderDayProgressionTracker.java
@@ -1,0 +1,65 @@
+package org.octri.notification.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * Interface for tracking progression through a series of reminder days.
+ */
+public interface ReminderDayProgressionTracker {
+
+	/**
+	 * @return The anchor date that followup days will be calculated from
+	 */
+	public LocalDate getStartDate();
+
+	/**
+	 * The series of reminder days this tracker follows (e.g., [1, 2, 4, 7]).
+	 *
+	 * @return an immutable list of integers representing the reminder days
+	 */
+	public List<Integer> getReminderDays();
+
+	/**
+	 * @return The current index in the progression list
+	 */
+	public int getCurrentIndex();
+
+	/**
+	 * Update the current index.
+	 * 
+	 * @param index
+	 *            the new index
+	 */
+	public void setCurrentIndex(int index);
+
+	/**
+	 * @return The current day in the series.
+	 */
+	public default int getCurrentDay() {
+		return getReminderDays().get(getCurrentIndex());
+	}
+
+	/**
+	 * @return the date corresponding to the current index calculated from the start date of the series
+	 */
+	public default LocalDate getCurrentDate() {
+		return getStartDate().plusDays(getCurrentDay());
+	}
+
+	/**
+	 * @return Whether the tracker is currently at the last item in the series.
+	 */
+	public default boolean isFinal() {
+		return getCurrentIndex() >= getReminderDays().size() - 1;
+	}
+
+	/**
+	 * Advances to the next index in the series if possible.
+	 */
+	public default void advance() {
+		if (!isFinal()) {
+			setCurrentIndex(getCurrentIndex() + 1);
+		}
+	}
+}

--- a/src/main/java/org/octri/notification/domain/ValidationResult.java
+++ b/src/main/java/org/octri/notification/domain/ValidationResult.java
@@ -1,0 +1,8 @@
+package org.octri.notification.domain;
+
+/**
+ * Record encompassing the result of the validation
+ */
+public record ValidationResult(boolean successful, String invalidReason) {
+
+}

--- a/src/main/java/org/octri/notification/metadata/EmptyMetadata.java
+++ b/src/main/java/org/octri/notification/metadata/EmptyMetadata.java
@@ -1,0 +1,8 @@
+package org.octri.notification.metadata;
+
+/**
+ * Empty notification metadata for notifications without parameters.
+ */
+public class EmptyMetadata implements NotificationMetadata {
+
+}

--- a/src/main/java/org/octri/notification/metadata/NotificationMetadata.java
+++ b/src/main/java/org/octri/notification/metadata/NotificationMetadata.java
@@ -1,0 +1,8 @@
+package org.octri.notification.metadata;
+
+/**
+ * An interface representing NotificationMetadata that may be required for validation and processing
+ */
+public interface NotificationMetadata {
+
+}

--- a/src/main/java/org/octri/notification/registry/MissingHandlerException.java
+++ b/src/main/java/org/octri/notification/registry/MissingHandlerException.java
@@ -1,0 +1,17 @@
+package org.octri.notification.registry;
+
+/**
+ * Exception thrown when a required handler is missing.
+ */
+public class MissingHandlerException extends Exception {
+
+	/**
+	 * 
+	 * @param message
+	 *            the exception message
+	 */
+	public MissingHandlerException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/org/octri/notification/registry/NotificationHandler.java
+++ b/src/main/java/org/octri/notification/registry/NotificationHandler.java
@@ -1,0 +1,84 @@
+package org.octri.notification.registry;
+
+import org.octri.notification.dispatch.NotificationDispatcher;
+import org.octri.notification.domain.ProcessingMode;
+import org.octri.notification.metadata.NotificationMetadata;
+import org.octri.notification.validator.NotificationValidator;
+import org.octri.notification.view.NotificationViewer;
+
+/**
+ * This class describes all the information that needs to be provided to handle a notification. It is used by the
+ * {@link NotificationTypeRegistry} to allow applications to define their own notification types and create a handler
+ * for them.
+ */
+public class NotificationHandler {
+
+	private final ProcessingMode processingMode;
+	private final Class<? extends NotificationMetadata> metadataClass;
+	private final NotificationValidator validator;
+	private final NotificationDispatcher dispatcher;
+	private final NotificationViewer viewer;
+
+	/**
+	 * 
+	 * @param processingMode
+	 *            the processing mode of the notification type
+	 * @param metadataClass
+	 *            the metadata class needed by the notification type
+	 * @param validator
+	 *            the validator for the notification type
+	 * @param dispatcher
+	 *            the dispatcher for the notification type
+	 * @param viewer
+	 *            the metadata viewer for the notification type
+	 */
+	public NotificationHandler(ProcessingMode processingMode, Class<? extends NotificationMetadata> metadataClass,
+			NotificationValidator validator, NotificationDispatcher dispatcher, NotificationViewer viewer) {
+		this.processingMode = processingMode;
+		this.metadataClass = metadataClass;
+		this.validator = validator;
+		this.dispatcher = dispatcher;
+		this.viewer = viewer;
+	}
+
+	/**
+	 * 
+	 * @return the processing mode of the notification type
+	 */
+	public ProcessingMode getProcessingMode() {
+		return processingMode;
+	}
+
+	/**
+	 * 
+	 * @return the metadata class needed by the notification type
+	 */
+	public Class<? extends NotificationMetadata> getMetadataClass() {
+		return metadataClass;
+	}
+
+	/**
+	 * 
+	 * @return the validator for the notification type
+	 */
+	public NotificationValidator getValidator() {
+		return validator;
+	}
+
+	/**
+	 * 
+	 * @return the dispatcher for the notification type
+	 */
+	public NotificationDispatcher getDispatcher() {
+		return dispatcher;
+	}
+
+	/**
+	 * 
+	 * @return the metadata viewer for the notification type
+	 */
+	public NotificationViewer getViewer() {
+		return viewer;
+	}
+
+}

--- a/src/main/java/org/octri/notification/registry/NotificationStatusRegistry.java
+++ b/src/main/java/org/octri/notification/registry/NotificationStatusRegistry.java
@@ -1,0 +1,72 @@
+package org.octri.notification.registry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import org.octri.notification.batch.NotificationItemReader;
+import org.octri.notification.batch.NotificationItemWriter;
+import org.octri.notification.domain.DefaultNotificationStatus;
+import org.octri.notification.domain.NotificationStatus;
+import org.springframework.stereotype.Component;
+
+/**
+ * This component allows applications to register or deregister a {@link NotificationStatus}. This library expects to
+ * use values in the {@link DefaultNotificationStatus} in the {@link NotificationItemReader} and
+ * {@link NotificationItemWriter}, so these Beans would need to be overridden if an application needs to support
+ * custom statuses.
+ */
+@Component
+public class NotificationStatusRegistry {
+
+	private List<NotificationStatus> statuses = new ArrayList<>();
+
+	/**
+	 * Initialize the registry with the default statuses
+	 */
+	public NotificationStatusRegistry() {
+		statuses.addAll(Arrays.asList(DefaultNotificationStatus.values()));
+	}
+
+	/**
+	 * Register a new NotificationStatus, removing any previous status with the same name.
+	 * 
+	 * @param notificationStatus
+	 *            the status to register
+	 */
+	public void register(NotificationStatus notificationStatus) {
+		statuses.removeIf(s -> s.name().equals(notificationStatus.name()));
+		statuses.add(notificationStatus);
+	}
+
+	/**
+	 * Remove the notification status if it exists
+	 * 
+	 * @param notificationStatus
+	 *            the status to remove
+	 */
+	public void deregister(NotificationStatus notificationStatus) {
+		statuses.remove(notificationStatus);
+	}
+
+	/**
+	 * 
+	 * @return a list of statuses sorted by the ordinal value
+	 */
+	public List<NotificationStatus> getStatuses() {
+		statuses.sort(Comparator.comparing(NotificationStatus::ordinal));
+		return statuses;
+	}
+
+	/**
+	 * @param name
+	 *            The name of the NotificationStatus
+	 * @return the NotificationStatus object for the given name
+	 */
+	public Optional<NotificationStatus> getStatusByName(String name) {
+		return statuses.stream().filter(s -> s.name().equals(name)).findFirst();
+	}
+
+}

--- a/src/main/java/org/octri/notification/registry/NotificationTypeRegistry.java
+++ b/src/main/java/org/octri/notification/registry/NotificationTypeRegistry.java
@@ -1,0 +1,75 @@
+package org.octri.notification.registry;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.octri.notification.dispatch.NotificationDispatcher;
+import org.octri.notification.domain.ProcessingMode;
+import org.octri.notification.metadata.NotificationMetadata;
+import org.octri.notification.validator.NotificationValidator;
+import org.octri.notification.view.NotificationViewer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+/**
+ * The registry for adding a new NotificationType and NotificationHandler.
+ */
+@Component
+public class NotificationTypeRegistry {
+
+	private static final Logger logger = LoggerFactory.getLogger(NotificationTypeRegistry.class);
+
+	private final Map<String, NotificationHandler> handlers = new ConcurrentHashMap<>();
+
+	/**
+	 * 
+	 * @param type
+	 *            a unique string representation of the Notification type
+	 * @param mode
+	 *            the node this type uses for processing (IMMEDIATE or SCHEDULED)
+	 * @param metadataClass
+	 *            the metadata class required for processing this Notification type
+	 * @param validator
+	 *            the validator for this Notification type
+	 * @param dispatcher
+	 *            the dispatcher for this Notification type
+	 * @param viewer
+	 *            the viewer for the metadata of this Notification type
+	 */
+	public void register(String type, ProcessingMode mode, Class<? extends NotificationMetadata> metadataClass,
+			NotificationValidator validator, NotificationDispatcher dispatcher, NotificationViewer viewer) {
+		Assert.notNull(validator, "Validator must not be null");
+		Assert.notNull(dispatcher, "Dispatcher must not be null");
+		logger.debug("Registering notification type: {} with mode {}/validator {}/dispatcher {}/viewer {}", type,
+				mode.name(),
+				validator.getClass().getSimpleName(),
+				dispatcher.getClass().getSimpleName(),
+				viewer.getClass().getName());
+		if (handlers.containsKey(type)) {
+			logger.warn("Notification type {} is already registered. Overwriting.", type);
+		}
+		handlers.put(type, new NotificationHandler(mode, metadataClass, validator, dispatcher, viewer));
+	}
+
+	/**
+	 * 
+	 * @return the set of types that are registered
+	 */
+	public Set<String> getRegisteredTypes() {
+		return handlers.keySet();
+	}
+
+	/**
+	 * 
+	 * @param type
+	 *            the type string
+	 * @return the NotificationHandler for the given type
+	 */
+	public NotificationHandler getHandler(String type) {
+		return handlers.get(type);
+	}
+
+}

--- a/src/main/java/org/octri/notification/repository/NotificationRepository.java
+++ b/src/main/java/org/octri/notification/repository/NotificationRepository.java
@@ -1,0 +1,46 @@
+package org.octri.notification.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.octri.notification.domain.DefaultNotificationStatus;
+import org.octri.notification.domain.Notification;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.CrudRepository;
+
+/**
+ * The repository for working with notifications in the database
+ */
+public interface NotificationRepository extends CrudRepository<Notification, Long> {
+
+	/**
+	 * The query to get Twilio notifications that need to be checked for final disposition
+	 */
+	static final String queuedTwilioNotificationQuery = """
+			SELECT *
+			FROM notification
+			WHERE notification_status = 'SENT'
+			  AND JSON_TYPE(notification_status_metadata->'$.dispatchResult') <> 'NULL'
+			  AND JSON_CONTAINS_PATH(notification_status_metadata->>'$.dispatchResult.deliveryDetails', 'one', '$.accountSid')
+			  AND JSON_UNQUOTE(JSON_EXTRACT(notification_status_metadata->>'$.dispatchResult.deliveryDetails', '$.status')) = 'QUEUED'
+			""";
+
+	/**
+	 * 
+	 * @param notificationStatus
+	 *            the notification status of notifications to find
+	 * @param currentDate
+	 *            the date to check for notifications against
+	 * @return the notifications with the given status scheduled before or on the date passed in
+	 */
+	List<Notification> findByNotificationStatusAndDateScheduledLessThanEqual(
+			DefaultNotificationStatus notificationStatus,
+			LocalDate currentDate);
+
+	/**
+	 * 
+	 * @return all the Twilio notifications that have not been checked for final disposition
+	 */
+	@Query(value = queuedTwilioNotificationQuery, nativeQuery = true)
+	List<Notification> findAllQueuedTwilioNotifications();
+}

--- a/src/main/java/org/octri/notification/service/NotificationService.java
+++ b/src/main/java/org/octri/notification/service/NotificationService.java
@@ -1,0 +1,57 @@
+package org.octri.notification.service;
+
+import org.octri.notification.batch.NotificationBatchJob;
+import org.octri.notification.domain.Notification;
+import org.octri.notification.domain.ProcessingMode;
+import org.octri.notification.registry.NotificationTypeRegistry;
+import org.octri.notification.repository.NotificationRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * Service for working with Notifications
+ */
+@Service
+public class NotificationService {
+
+	private final NotificationRepository notificationRepository;
+	private final NotificationTypeRegistry notificationTypeRegistry;
+	private final NotificationBatchJob notificationBatchJob;
+
+	/**
+	 * 
+	 * @param notificationRepository
+	 *            the notification repository
+	 * @param notificationTypeRegistry
+	 *            the notification type registry
+	 * @param notificationBatchJob
+	 *            the notification batch job
+	 */
+	public NotificationService(NotificationRepository notificationRepository,
+			NotificationTypeRegistry notificationTypeRegistry, NotificationBatchJob notificationBatchJob) {
+		this.notificationRepository = notificationRepository;
+		this.notificationTypeRegistry = notificationTypeRegistry;
+		this.notificationBatchJob = notificationBatchJob;
+	}
+
+	/**
+	 * Persist a new notification. If the registered Notification type needs immediate processing, kick off the batch
+	 * job.
+	 * 
+	 * @param notification
+	 *            the notification to save
+	 * @return the persisted notification
+	 * @throws Exception
+	 *             exception thrown by the JobLauncher
+	 */
+	public Notification createNew(Notification notification) throws Exception {
+		assert notification.getId() == null;
+		Notification saved = notificationRepository.save(notification);
+		var handler = notificationTypeRegistry.getHandler(notification.getNotificationType());
+		if (handler != null && ProcessingMode.IMMEDIATE.equals(handler.getProcessingMode())) {
+			notificationBatchJob.runImmediateNotificationJob();
+		}
+
+		return saved;
+	}
+
+}

--- a/src/main/java/org/octri/notification/validator/NotificationValidator.java
+++ b/src/main/java/org/octri/notification/validator/NotificationValidator.java
@@ -1,0 +1,19 @@
+package org.octri.notification.validator;
+
+import org.octri.notification.domain.Notification;
+import org.octri.notification.domain.ValidationResult;
+
+/**
+ * Interface for a component that can validate whether a Notification should be sent
+ */
+public interface NotificationValidator {
+
+	/**
+	 * 
+	 * @param notification
+	 *            the Notification to validate
+	 * @return the result of the validation
+	 */
+	public ValidationResult validate(Notification notification);
+
+}

--- a/src/main/java/org/octri/notification/view/EmptyMetadataViewer.java
+++ b/src/main/java/org/octri/notification/view/EmptyMetadataViewer.java
@@ -1,0 +1,22 @@
+package org.octri.notification.view;
+
+import org.octri.notification.domain.Notification;
+import org.octri.notification.metadata.EmptyMetadata;
+
+/**
+ * Notification viewer for notifications that use the {@link EmptyMetadata} class. The recipient uuid is returned as a
+ * default.
+ */
+public class EmptyMetadataViewer implements NotificationViewer {
+
+	@Override
+	public String getRecipientView(Notification notification) {
+		return notification.getRecipientUuid();
+	}
+
+	@Override
+	public String getMetadataView(Notification notification) {
+		return null;
+	}
+
+}

--- a/src/main/java/org/octri/notification/view/NotificationStatusSelectOption.java
+++ b/src/main/java/org/octri/notification/view/NotificationStatusSelectOption.java
@@ -1,0 +1,50 @@
+package org.octri.notification.view;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.octri.common.view.SelectOption;
+import org.octri.notification.domain.NotificationStatus;
+
+/**
+ * A select option for NotificationStatus values
+ *
+ * @param <T>
+ *            a type implementing NotificationStatus
+ */
+public class NotificationStatusSelectOption<T extends NotificationStatus> extends SelectOption<T> {
+
+	/**
+	 * Constructor
+	 *
+	 * @param choice
+	 *            - item
+	 * @param selected
+	 *            - The selected item; may be null
+	 */
+	public NotificationStatusSelectOption(T choice, T selected) {
+		super(choice, selected);
+		this.setValue(choice.name());
+		this.setLabel(choice.getLabel());
+	}
+
+	/**
+	 * Given a collection of NotificationStatuses and the selected status, provides a list of objects that can be used
+	 * directly by mustachejs for rendering.
+	 *
+	 * @param <T>
+	 *            a type extending NotificationStatus
+	 * @param iter
+	 *            an iterable collection of NotificationStatus values
+	 * @param selected
+	 *            the current selection
+	 * @return a list of select options for the values in the collection
+	 */
+	public static <T extends NotificationStatus> List<NotificationStatusSelectOption<T>> fromStatuses(Iterable<T> iter,
+			T selected) {
+		return StreamSupport.stream(iter.spliterator(), false)
+				.map(item -> new NotificationStatusSelectOption<T>(item, selected))
+				.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/org/octri/notification/view/NotificationViewer.java
+++ b/src/main/java/org/octri/notification/view/NotificationViewer.java
@@ -1,0 +1,25 @@
+package org.octri.notification.view;
+
+import org.octri.notification.domain.Notification;
+
+/**
+ * Interface for customizing the view of the notification and its metadata.
+ */
+public interface NotificationViewer {
+
+	/**
+	 * 
+	 * @param notification
+	 *            the notification whose recipient is to be viewed
+	 * @return a user-friendly view of the notification recipient
+	 */
+	public String getRecipientView(Notification notification);
+
+	/**
+	 * @param notification
+	 *            the notification whose metadata is to be viewed
+	 * @return a user-friendly view of the notification metadata
+	 */
+	public String getMetadataView(Notification notification);
+
+}

--- a/src/main/resources/mustache-templates/components/notification_list_nav_items.mustache
+++ b/src/main/resources/mustache-templates/components/notification_list_nav_items.mustache
@@ -1,0 +1,12 @@
+{{#notificationStatuses}}
+<li class="nav-item">
+    <a class="toggle-item nav-link nav-link-light {{#-first}}active{{/-first}}" {{#descending}}data-orientation= "desc"{{/descending}} data-toggle="{{label}}" href="#">
+    {{label}}
+    </a>
+</li>
+{{/notificationStatuses}}
+<li class="nav-item">
+    <a class="toggle-item nav-link nav-link-light" data-toggle="all" data-page-to-today href="#">
+    {{#i18n}}notificationList.filter.all{{/i18n}}
+    </a>
+</li>

--- a/src/main/resources/mustache-templates/notification/form.mustache
+++ b/src/main/resources/mustache-templates/notification/form.mustache
@@ -1,0 +1,67 @@
+{{>components/form_start}}
+{{#entity}}
+<div class="form-group">
+    <label for="date_scheduled" class="form-label required-field">{{#i18n}}notification.dateScheduled.label{{/i18n}}</label>
+    <div class="input-group date-control">
+        <input type="text" class="form-control" id="date_scheduled" name="dateScheduled" value="{{#dateScheduled}}{{.}}{{/dateScheduled}}"
+            pattern="{{octriViewConfig.datePatternRegex}}" placeholder="{{octriViewConfig.datePatternPlaceholder}}" autocomplete="off"
+            data-provide="datepicker" data-date-format="{{octriViewConfig.datePattern}}">
+        <span class="input-group-text rounded-end"><i class="far fa-calendar-alt"></i></span>
+    </div>
+    <div class="invalid-feedback">{{#i18n}}notification.dateScheduled.validationMessage{{/i18n}}</div>
+</div>
+
+<div class="form-group">
+    <label for="recipient_uuid" class="form-label required-field">{{#i18n}}notification.recipient.label{{/i18n}}</label>
+    <select class="form-select" id="recipient_uuid" name="recipientUuid" value="{{#recipientUuid}}{{.}}{{/recipientUuid}}" required>
+        <option value="">-- {{#i18n}}system.entity.select{{/i18n}} --</option>
+        {{#recipientOptions}}
+        <option value="{{uuid}}" {{#selected}}selected{{/selected}}>{{label}}</option>
+        {{/recipientOptions}}
+    </select>
+    <div class="invalid-feedback">{{#i18n}}notification.recipient.validationMessage{{/i18n}}</div>
+</div>
+
+<div class="form-group">
+    <label for="notification_status" class="form-label required-field">{{#i18n}}notification.notificationStatus.label{{/i18n}}</label>
+    <select class="form-select" id="notification_status" name="notificationStatus" value="{{#notificationStatus}}{{.}}{{/notificationStatus}}" required>
+        <option value="">-- {{#i18n}}system.entity.select{{/i18n}} --</option>
+        {{#notificationStatusOptions}}
+        <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>
+        {{/notificationStatusOptions}}
+    </select>
+    <div class="invalid-feedback">{{#i18n}}notification.notificationStatus.validationMessage{{/i18n}}</div>
+</div>
+
+<div class="form-group">
+    <label for="notification_type" class="form-label required-field">{{#i18n}}notification.notificationType.label{{/i18n}}</label>
+    <select class="form-select" id="notification_type" name="notificationType" value="{{#notificationType}}{{.}}{{/notificationType}}" required>
+        <option value="">-- {{#i18n}}system.entity.select{{/i18n}} --</option>
+        {{#notificationTypeOptions}}
+        <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>
+        {{/notificationTypeOptions}}
+    </select>
+    <div class="invalid-feedback">{{#i18n}}notification.notificationType.validationMessage{{/i18n}}</div>
+</div>
+
+<div class="form-group">
+    <label for="notification_metadata" class="form-label">{{#i18n}}notification.notificationMetadata.label{{/i18n}}</label>
+    <input type="text" class="form-control" id="notification_metadata" name="notificationMetadata" value="{{#notificationMetadata}}{{.}}{{/notificationMetadata}}" >
+</div>
+
+<div class="form-group">
+    <label for="date_time_processed" class="form-label">{{#i18n}}notification.dateTimeProcessed.label{{/i18n}}</label>
+    <div class="input-group date-control">
+        <input type="text" class="form-control" id="date_time_processed" name="dateTimeProcessed" value="{{#dateTimeProcessed}}{{.}}{{/dateTimeProcessed}}" pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}" placeholder="yyyy-mm-dd" autocomplete="off" data-provide="datepicker">
+        <span class="input-group-text rounded-end"><i class="far fa-calendar-alt"></i></span>
+    </div>
+    <div class="invalid-feedback">{{#i18n}}notification.dateTimeProcessed.validationMessage{{/i18n}}</div>
+</div>
+
+<div class="form-group">
+    <label for="notification_status_metadata" class="form-label">{{#i18n}}notification.notificationStatusMetadata.label{{/i18n}}</label>
+    <input type="text" class="form-control" id="notification_status_metadata" name="notificationStatusMetadata" value="{{#notificationStatusMetadata}}{{.}}{{/notificationStatusMetadata}}" >
+</div>
+
+{{/entity}}
+{{>components/form_end}}

--- a/src/main/resources/mustache-templates/notification/list.mustache
+++ b/src/main/resources/mustache-templates/notification/list.mustache
@@ -1,0 +1,62 @@
+{{>layout/header}}
+<div class="container">
+    <h1>{{entityName}} {{#i18n}}system.entity.list{{/i18n}}</h1>
+    {{>components/messages}}
+    {{#isSuper}}
+        {{>components/new_entity}}
+    {{/isSuper}}
+    {{#entity_list.0}}
+    <div class="filtered-list">
+        <ul id="notification-list_toggle-menu" class="nav nav-pills mb-2">
+            {{>components/notification_list_nav_items}}
+        </ul>
+        <div class="table-responsive-md">
+        <table id="notification-list" class="table table-striped table-bordered filtered">
+        <thead>
+        <tr>
+            <th class="page-to-today-column">{{#i18n}}notification.dateScheduled.label{{/i18n}}</th>
+            <th>{{#i18n}}notification.participant.label{{/i18n}}</th>
+            <th class="filter-column">{{#i18n}}notification.notificationStatus.label{{/i18n}}</th>
+            <th>{{#i18n}}notification.notificationType.label{{/i18n}}</th>
+            <th>{{#i18n}}notification.notificationMetadata.label{{/i18n}}</th>
+            <th>{{#i18n}}notification.dateTimeProcessed.label{{/i18n}}</th>
+            <th>{{#i18n}}notification.notificationStatusMetadata.label{{/i18n}}</th>
+            <th>{{#i18n}}system.entity.actions{{/i18n}}</th>
+        </tr>
+        </thead>
+        <tbody>
+        {{#entity_list}}
+        <tr>
+            <td data-order="{{#dateScheduledIso}}{{.}}{{/dateScheduledIso}}">{{#dateScheduled}}{{.}}{{/dateScheduled}}</td>
+            <!--<td>{{#recipient}}<a href="{{req.contextPath}}/admin/participant/{{id}}">{{label}}</a> ({{#participantType}}{{.}}{{/participantType}}){{/recipient}}</td>-->
+            <td>{{#notificationRecipientView}}{{{.}}}{{/notificationRecipientView}}</td>
+            <td>{{#notificationStatus}}{{label}}{{/notificationStatus}}</td>
+            <td>{{#notificationType}}{{.}}{{/notificationType}}</td>
+            <td>{{#notificationMetadataView}}{{{.}}}{{/notificationMetadataView}}</td>
+            <td>{{#dateTimeProcessed}}{{.}}{{/dateTimeProcessed}}</td>
+            <td>
+                {{#statusMetadata}}
+                    {{#validationResult}}
+                        {{^successful}}
+                            Validation failed: {{#invalidReason}}{{.}}{{/invalidReason}}
+                        {{/successful}}
+                    {{/validationResult}}
+                    {{#dispatchResult}}
+                        {{#successful}}
+                            No errors
+                        {{/successful}}
+                        {{^successful}}
+                            Send failed: {{#errorMessage}}{{.}}{{/errorMessage}}
+                        {{/successful}}                       
+                    {{/dispatchResult}}
+                {{/statusMetadata}}
+            </td>
+            <td><a href="{{req.contextPath}}{{baseRoute}}/{{id}}">View</a></td>
+        </tr>
+        {{/entity_list}}
+        </tbody>
+        </table>
+    </div>
+    {{/entity_list.0}}
+</div>
+{{>layout/footer}}

--- a/src/main/resources/mustache-templates/notification/show.mustache
+++ b/src/main/resources/mustache-templates/notification/show.mustache
@@ -1,0 +1,65 @@
+{{>layout/header}}
+<div class="container">
+    <h1>{{entityName}}</h1>
+    {{>components/messages}}
+    <div>
+        {{#entity}}
+        <h5>{{#i18n}}notification.dateScheduled.label{{/i18n}}</h5>
+        <p>
+            {{#dateScheduled}}{{.}}{{/dateScheduled}}
+            {{^dateScheduled}}<span class="text-muted">{{#i18n}}system.entity.none{{/i18n}}</span>{{/dateScheduled}}
+        </p>
+        <h5>{{#i18n}}notification.recipient.label{{/i18n}}</h5>
+        <p>
+            {{#notificationRecipientView}}{{{.}}}{{/notificationRecipientView}}
+            {{^notificationRecipientView}}<span class="text-muted">{{#i18n}}system.entity.none{{/i18n}}</span>{{/notificationRecipientView}}
+        </p>
+        <h5>{{#i18n}}notification.notificationStatus.label{{/i18n}}</h5>
+        <p>
+            {{#notificationStatus}}{{label}}{{/notificationStatus}}
+            {{^notificationStatus}}<span class="text-muted">{{#i18n}}system.entity.none{{/i18n}}</span>{{/notificationStatus}}
+        </p>
+        <h5>{{#i18n}}notification.notificationType.label{{/i18n}}</h5>
+        <p>
+            {{#notificationType}}{{.}}{{/notificationType}}
+            {{^notificationType}}<span class="text-muted">{{#i18n}}system.entity.none{{/i18n}}</span>{{/notificationType}}
+        </p>
+        <h5>{{#i18n}}notification.notificationMetadata.label{{/i18n}}</h5>
+        <p>
+            {{#notificationMetadataView}}{{{.}}}{{/notificationMetadataView}}
+            {{^notificationMetadataView}}<span class="text-muted">{{#i18n}}system.entity.none{{/i18n}}</span>{{/notificationMetadataView}}
+        </p>
+        <h5>{{#i18n}}notification.dateTimeProcessed.label{{/i18n}}</h5>
+        <p>
+            {{#dateTimeProcessed}}{{.}}{{/dateTimeProcessed}}
+            {{^dateTimeProcessed}}<span class="text-muted">{{#i18n}}system.entity.none{{/i18n}}</span>{{/dateTimeProcessed}}
+        </p>
+        <h5>{{#i18n}}notification.notificationStatusMetadata.label{{/i18n}}</h5>
+        {{#statusMetadata}}
+            <div class="card">
+                <div class="card-body">
+                    {{#validationResult}}
+                    {{^successful}}
+                        <h5><i class="fa-solid fa-square-xmark text-danger"></i> Validation Failed</h5>
+                        <p>Invalid Reason: {{#invalidReason}}{{.}}{{/invalidReason}}</p>
+                    {{/successful}}
+                    {{/validationResult}}
+                    {{#dispatchResult}}
+                    <h5>{{#successful}}<i class="fa-solid fa-square-check text-success"></i> Sent{{/successful}}{{^successful}}<i class="fa-solid fa-square-xmark text-danger"></i> Not Sent{{/successful}}</h5>
+                    <ul>
+                        <li><strong>Recipient:</strong> {{#recipient}}{{.}}{{/recipient}}</li>
+                        <li><strong>Message:</strong> {{#messageContent}}{{.}}{{/messageContent}}</li>
+                        {{^successful}}<li>Error Message: {{#errorMessage}}{{.}}{{/errorMessage}}</li>{{/successful}}
+                        {{#deliveryDetails}}<li><strong>Delivery Details:</strong>
+                            <div id="delivery_details" data-delivery-details="{{.}}"></div>
+                        </li>{{/deliveryDetails}}
+                    </ul>
+                    {{/dispatchResult}}
+                </div>
+            </div>
+        {{/statusMetadata}}
+        {{>components/show_links_editing_enabled}}
+        {{/entity}}
+    </div>
+</div>
+{{>layout/footer}}

--- a/src/test/java/org/octri/notification/NotificationTestUtil.java
+++ b/src/test/java/org/octri/notification/NotificationTestUtil.java
@@ -1,0 +1,27 @@
+package org.octri.notification;
+
+import java.time.LocalDate;
+
+import org.octri.notification.domain.Notification;
+import org.octri.notification.domain.Recipient;
+import org.octri.notification.domain.ValidationResult;
+import org.octri.notification.metadata.NotificationMetadata;
+
+public class NotificationTestUtil {
+
+	public static Notification createNotification(String notificationType,
+			Recipient recipient,
+			NotificationMetadata notificationMetadata,
+			LocalDate dateScheduled) {
+		var notification = new Notification(recipient);
+		notification.setNotificationType(notificationType);
+		notification.setNotificationMetadata(notificationMetadata);
+		notification.setDateScheduled(dateScheduled);
+		return notification;
+	}
+
+	public static boolean invalidReasonMatches(ValidationResult status, String reason) {
+		return status.invalidReason() != null && status.invalidReason().contains(reason);
+	}
+
+}

--- a/src/test/java/org/octri/notification/ProgressionTrackerMetadataExample.java
+++ b/src/test/java/org/octri/notification/ProgressionTrackerMetadataExample.java
@@ -1,0 +1,17 @@
+package org.octri.notification;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.octri.notification.domain.AbstractReminderDayProgressionTracker;
+
+public class ProgressionTrackerMetadataExample extends AbstractReminderDayProgressionTracker {
+
+	public ProgressionTrackerMetadataExample() {
+
+	}
+
+	public ProgressionTrackerMetadataExample(LocalDate startDate, List<Integer> reminderDays) {
+		super(startDate, reminderDays);
+	}
+}

--- a/src/test/java/org/octri/notification/RecipientExample.java
+++ b/src/test/java/org/octri/notification/RecipientExample.java
@@ -1,0 +1,23 @@
+package org.octri.notification;
+
+import org.octri.notification.domain.Recipient;
+
+public class RecipientExample implements Recipient {
+
+	String uuid;
+
+	public RecipientExample(String uuid) {
+		this.uuid = uuid;
+	}
+
+	@Override
+	public String getUuid() {
+		return uuid;
+	}
+
+	@Override
+	public String getLabel() {
+		return uuid;
+	}
+
+}

--- a/src/test/java/org/octri/notification/batch/NotificationItemWriterTest.java
+++ b/src/test/java/org/octri/notification/batch/NotificationItemWriterTest.java
@@ -1,0 +1,93 @@
+package org.octri.notification.batch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.octri.notification.NotificationTestUtil;
+import org.octri.notification.ProgressionTrackerMetadataExample;
+import org.octri.notification.RecipientExample;
+import org.octri.notification.domain.DefaultNotificationStatus;
+import org.octri.notification.domain.DispatchResult;
+import org.octri.notification.domain.Notification;
+import org.octri.notification.domain.Notification.NotificationStatusMetadata;
+import org.octri.notification.domain.ValidationResult;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public class NotificationItemWriterTest {
+
+	private final static LocalDate TODAY = LocalDate.now();
+	private final static LocalDate LAST_WEEK = TODAY.minusDays(7);
+	private final static String recipientUuid1 = UUID.randomUUID().toString();
+
+	@Test
+	void testNextNotificationIsFinal() throws JsonProcessingException {
+		ProgressionTrackerMetadataExample metadata = new ProgressionTrackerMetadataExample(TODAY, List.of(0));
+		var notification = NotificationTestUtil.createNotification("example", new RecipientExample(recipientUuid1),
+				metadata, TODAY);
+		var nextNotification = NotificationItemWriter.nextNotification(notification, metadata);
+		assertTrue(nextNotification.isEmpty(), "A final notification has no next notification.");
+	}
+
+	@Test
+	void testNextNotificationIsPast() throws JsonProcessingException {
+		ProgressionTrackerMetadataExample metadata = new ProgressionTrackerMetadataExample(LAST_WEEK,
+				List.of(0, 1, 2, 3));
+		var notification = NotificationTestUtil.createNotification("example", new RecipientExample(recipientUuid1),
+				metadata, TODAY);
+		var nextNotification = NotificationItemWriter.nextNotification(notification, metadata);
+		assertTrue(nextNotification.isEmpty(), "All followup notifications are in the past.");
+	}
+
+	@Test
+	void testNextNotificationIsFirstFuture() throws JsonProcessingException {
+		ProgressionTrackerMetadataExample metadata = new ProgressionTrackerMetadataExample(LAST_WEEK,
+				List.of(0, 6, 7, 8, 10));
+		var notification = NotificationTestUtil.createNotification("example", new RecipientExample(recipientUuid1),
+				metadata, TODAY);
+		var nextNotification = NotificationItemWriter.nextNotification(notification, metadata);
+		assertTrue(nextNotification.isPresent(), "A next notification was returned.");
+		assertTrue(nextNotification.get().getDateScheduled().isAfter(TODAY), "The scheduled date is after today");
+		var newMetadata = nextNotification.get().getNotificationMetadata(ProgressionTrackerMetadataExample.class);
+		assertTrue(newMetadata.getCurrentIndex() == 3,
+				"Days 6 and 7 where skipped because they are not in the future.");
+	}
+
+	@Test
+	void testIsNotificationValid() {
+		var validMetadata = new NotificationStatusMetadata(new ValidationResult(true, null), null);
+		assertTrue(NotificationItemWriter.isNotificationValid(validMetadata),
+				"Notification is valid if validation result is successful");
+
+		var invalidMetadata = new NotificationStatusMetadata(new ValidationResult(false, null), null);
+		assertFalse(NotificationItemWriter.isNotificationValid(invalidMetadata),
+				"Notification is invalid if validation result is not successful");
+	}
+
+	@Test
+	void testUpdateDispatchedNotification() {
+		var validDispatch = new DispatchResult(true, null, null, null, null);
+		var notification = NotificationItemWriter.updateDispatchedNotification(new Notification(),
+				new ValidationResult(true, null), validDispatch);
+		assertTrue(notification.getNotificationStatus().equals(DefaultNotificationStatus.SENT),
+				"Notification status is updated to SENT");
+
+		var invalidDispatch = new DispatchResult(false, null, null, null, null);
+		notification = NotificationItemWriter.updateDispatchedNotification(new Notification(),
+				new ValidationResult(true, null), invalidDispatch);
+		assertTrue(notification.getNotificationStatus().equals(DefaultNotificationStatus.INACTIVE),
+				"Notification status is updated to INACTIVE");
+	}
+
+	@Test
+	void testUpdateInvalidNotification() {
+		var notification = NotificationItemWriter.updateInvalidNotification(new Notification());
+		assertTrue(notification.getNotificationStatus().equals(DefaultNotificationStatus.INACTIVE),
+				"Notification status is updated to INACTIVE");
+	}
+}

--- a/src/test/java/org/octri/notification/dispatch/AbstractNotificationDispatcherTest.java
+++ b/src/test/java/org/octri/notification/dispatch/AbstractNotificationDispatcherTest.java
@@ -1,0 +1,111 @@
+package org.octri.notification.dispatch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.octri.messaging.exception.UnsuccessfulDeliveryException;
+import org.octri.messaging.service.MessageDeliveryService;
+import org.octri.notification.config.NotificationConfig;
+
+@ExtendWith(MockitoExtension.class)
+public class AbstractNotificationDispatcherTest {
+
+	@Mock
+	MessageDeliveryService messageDeliveryService;
+
+	@Mock
+	NotificationConfig notificationConfig;
+
+	TestNotificationDispatcher notificationDispatcher;
+
+	private static final String NOTIFICATION_SENDER_EMAIL = "admin@email.com";
+	private static final String NOTIFICATION_SENDER_SMS_NUMBER = "888-888-9999";
+	private static final String PARTICIPANT_EMAIL = "participant@email.com";
+	private static final String PARTICIPANT_MOBILE = "555-555-5555";
+	private static final String EMAIL_SUBJECT = "Test Subject";
+	private static final String CONTENT = "Test Content";
+
+	@BeforeEach
+	public void setup() {
+		notificationDispatcher = new TestNotificationDispatcher(messageDeliveryService,
+				notificationConfig, null);
+	}
+
+	@Test
+	void testSendEmail() {
+		mockNotificationConfig();
+		mockSuccessfulSendEmail();
+		var dispatchResult = notificationDispatcher.sendEmail(PARTICIPANT_EMAIL, EMAIL_SUBJECT, CONTENT);
+		assertTrue(dispatchResult.successful(), "Dispatch should be successful.");
+		assertNull(dispatchResult.errorMessage(), "Error message should not be present.");
+		assertTrue(dispatchResult.recipient().equals(PARTICIPANT_EMAIL), "Message recipient should match.");
+		assertTrue(dispatchResult.messageContent().equals(CONTENT), "Message content should match.");
+
+		mockFailedSendEmail();
+		dispatchResult = notificationDispatcher.sendEmail(PARTICIPANT_EMAIL, EMAIL_SUBJECT, CONTENT);
+		assertFalse(dispatchResult.successful(), "Dispatch should not be successful.");
+		assertNotNull(dispatchResult.errorMessage(), "Error message should be present.");
+		assertTrue(dispatchResult.recipient().equals(PARTICIPANT_EMAIL),
+				"Intended message recipient should still be present and match.");
+		assertTrue(dispatchResult.messageContent().equals(CONTENT),
+				"Intended message content should still be present and should match.");
+	}
+
+	@Test
+	void testSendSms() {
+		mockNotificationConfig();
+		mockSuccessfulSendSms();
+		var dispatchResult = notificationDispatcher.sendSms(PARTICIPANT_MOBILE, CONTENT);
+		assertTrue(dispatchResult.successful(), "Dispatch should be successful.");
+		assertNull(dispatchResult.errorMessage(), "Error message should not be present.");
+		assertTrue(dispatchResult.recipient().equals(PARTICIPANT_MOBILE), "Message recipient should match.");
+		assertTrue(dispatchResult.messageContent().equals(CONTENT), "Message content should match.");
+
+		mockFailedSendSms();
+		dispatchResult = notificationDispatcher.sendSms(PARTICIPANT_MOBILE, CONTENT);
+		assertFalse(dispatchResult.successful(), "Dispatch should not be successful.");
+		assertNotNull(dispatchResult.errorMessage(), "Error message should be present.");
+		assertTrue(dispatchResult.recipient().equals(PARTICIPANT_MOBILE),
+				"Intended message recipient should still be present and match.");
+		assertTrue(dispatchResult.messageContent().equals(CONTENT),
+				"Intended message content should still be present and should match.");
+	}
+
+	private void mockNotificationConfig() {
+		lenient().when(notificationConfig.getEmail()).thenReturn(NOTIFICATION_SENDER_EMAIL);
+		lenient().when(notificationConfig.getSmsNumber()).thenReturn(NOTIFICATION_SENDER_SMS_NUMBER);
+	}
+
+	private void mockSuccessfulSendEmail() {
+		when(messageDeliveryService.sendEmail(anyString(), anyString(), anyString(), anyString()))
+				.thenReturn(Optional.empty());
+	}
+
+	private void mockFailedSendEmail() {
+		when(messageDeliveryService.sendEmail(anyString(), anyString(), anyString(), anyString()))
+				.thenThrow(new UnsuccessfulDeliveryException("Failed to send email."));
+	}
+
+	private void mockSuccessfulSendSms() {
+		when(messageDeliveryService.sendSms(anyString(), anyString(), anyString()))
+				.thenReturn(Optional.empty());
+	}
+
+	private void mockFailedSendSms() {
+		when(messageDeliveryService.sendSms(anyString(), anyString(), anyString()))
+				.thenThrow(new UnsuccessfulDeliveryException("Failed to send email."));
+	}
+
+}

--- a/src/test/java/org/octri/notification/dispatch/TestNotificationDispatcher.java
+++ b/src/test/java/org/octri/notification/dispatch/TestNotificationDispatcher.java
@@ -1,0 +1,25 @@
+package org.octri.notification.dispatch;
+
+import org.octri.messaging.service.MessageDeliveryService;
+import org.octri.notification.config.NotificationConfig;
+import org.octri.notification.domain.DispatchResult;
+import org.octri.notification.domain.Notification;
+
+import com.samskivert.mustache.Mustache.Compiler;
+
+/**
+ * Concrete test class for {@link AbstractNotificationDispatcher}.
+ */
+public class TestNotificationDispatcher extends AbstractNotificationDispatcher {
+
+	public TestNotificationDispatcher(MessageDeliveryService messageDeliveryService,
+			NotificationConfig notificationConfig, Compiler mustacheCompiler) {
+		super(messageDeliveryService, notificationConfig, mustacheCompiler);
+	}
+
+	@Override
+	public DispatchResult handleDispatch(Notification notification) {
+		throw new UnsupportedOperationException("Unimplemented method 'handleDispatch'");
+	}
+
+}


### PR DESCRIPTION
# Overview

This provides an initial implementation of the Notification Library. I've added a few extension points:

- NotificationStatus is no longer an enumeration. Applications can define their own statuses using the NotificationStatusRegistry, but they would have to override some beans. I have not fully tested this functionality, so there may be some gotchas. I was able to override a status label and retain the name, and it worked.
- The NotificationViewer interface allows an application to define how the Recipient and the NotificationMetatada will appear on the Notification list/show pages. This ability already existed for metadata, but I added the Recipient viewer so that I could customize how a participant is shown. These are triple-bracketed in the Mustache templates to allow HTML, so in OPEN my participant shows as a hyperlink and the participant type and name are provided.

## Issues

CIS-3203

[X] Added to CHANGELOG.md

## Discussion

The build is currently failing because the common-lib isn't in Maven Central yet. Should we move that into Enterprise Cloud or move this into source.ohsu.edu? I'm guessing the former.

There are some outstanding items I'll put in a followup PR:

- Migration scripts
- Translations
- Dedicated properties file
- Autoconfiguration
- Potentially more flags for turning things off/on
- Documentation