### PR TITLE
CIS-3368 Publish SNAPSHOT Artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
   publish:
     name: Publish to Maven Central
     needs: build-java-source
-    if: github.ref_type == 'tag'
+    if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,14 +69,7 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Get version from POM
-        id: get-version
-        run: |
-          version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "version=$version" >> $GITHUB_ENV
-
       - name: Publish release to Maven Central
-        if: github.ref_type == 'tag' && !contains(env.version, '-SNAPSHOT')
         run: mvn deploy -DskipTests -Pci,publish
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Publish -SNAPSHOT releases to Maven Central. (CIS-3368)
+
 ## [0.2.0] - 2025-09-30
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,7 @@
 							<publishingServerId>central</publishingServerId>
 							<deploymentName>${project.name} ${project.version}</deploymentName>
 							<autoPublish>true</autoPublish>
+							<centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION
# Overview

Update the GitHub Actions build workflow to publish -SNAPSHOT artifacts to Maven Central, in addition to GitHub Packages.

## Issues

[CIS-3368](https://jirabp.ohsu.edu/browse/CIS-3368)

[X] Added to CHANGELOG.md
