### PR TITLE
CIS-3607 Notification Type Autodiscovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Declared NotificationValidator a functional interface for compile-time checking (CIS-3589)
-- Add automatic registration of notification types defined by a `NotificationTypeProvider` interface
+- Add automatic registration of notification types defined by a `NotificationTypeProvider` interface (CIS-3607)
 
 ## [2.0.0] - 2025-10-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Declared NotificationValidator a functional interface for compile-time checking (CIS-3589)
+- Add automatic registration of notification types defined by a `NotificationTypeProvider` interface
 
 ## [2.0.0] - 2025-10-22
 
 ### Changed
 
-- Potentially Breaking: Redesigned NotificationViewer interface to encourage thread safety. This only impacts applications that used the prepare method in 1.0.0. This has been replaced by prepareCache. 
+- Potentially Breaking: Redesigned NotificationViewer interface to encourage thread safety. This only impacts applications that used the prepare method in 1.0.0. This has been replaced by prepareCache.
 - Updated documentation for NotificationViewer
 
 ## [1.0.0] - 2025-10-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add automatic registration of notification types defined by a `NotificationTypeProvider` interface (CIS-3607)
+
 ## [2.1.0] - 2026-03-04
 
 ### Added
@@ -16,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Declared NotificationValidator a functional interface for compile-time checking (CIS-3589)
-- Add automatic registration of notification types defined by a `NotificationTypeProvider` interface (CIS-3607)
 
 ## [2.0.0] - 2025-10-22
 

--- a/NOTIFICATION_REGISTRATION.md
+++ b/NOTIFICATION_REGISTRATION.md
@@ -52,8 +52,8 @@ public class ClientWelcomeDispatcher implements NotificationDispatcher {
 	public DispatchResult handleDispatch(Notification notification) {
 		var participant = (Participant) notification.getRecipient();
 		try {
-			var deliveryDetails = messageDeliveryService.sendEmail(notificationProperties.getEmail(), 
-                participant.getEmail(),
+			var deliveryDetails = messageDeliveryService.sendEmail(notificationProperties.getEmail(),
+				participant.getEmail(),
 				"Message Subject",
 				"Message Content");
 			return new DispatchResult(true, messageContent, recipient,
@@ -173,11 +173,11 @@ This is how it will manifest in the Recipient and Info columns of the list page:
 
 Because the methods `getRecipientView` and `getMetadataView` will be called for every Notification, applications may want to set up a ThreadLocal cache to optimize these queries on the full list first. In this case, applications can override the `NotificationViewer` default method `prepareCache`:
 
-```
+```java
 	/**
 	 * Applications that need to fetch data for each notification can prefetch and cache in a ThreadLocal to optimize
 	 * performance.
-	 * 
+	 *
 	 * @param notifications
 	 *            the list of notifications that will be viewed
 	 * @return an AutoCloseable that will clear the cache when closed; default has no cache and returns a no-op
@@ -191,7 +191,7 @@ Because the methods `getRecipientView` and `getMetadataView` will be called for 
 
 This is how the implementation above would be rewritten to use a cache:
 
-```
+```java
 public class SurveyReminderViewer {
 
 	private final ParticipantService participantService;
@@ -258,7 +258,45 @@ public class SurveyReminderViewer {
 
 ## Register the Notification Type
 
-With all the necessary classes defined, use the [`NotificationTypeRegistry`](src/main/java/org/octri/notification/registry/NotificationTypeRegistry.java) to handle the new custom type.
+Once all of the necessary classes have been defined for your new notification, it needs to be registered wih the [`NotificationTypeRegistry`](src/main/java/org/octri/notification/registry/NotificationTypeRegistry.java). Notifications may be manually registered with the [`NotificationTypeRegistry`](src/main/java/org/octri/notification/registry/NotificationTypeRegistry.java) or registered automatically using the [`NotificationTypeProvider`](src/main/java/org/octri/notification/registry/NotificationTypeProvider.java) interface. While manual registration may be appropriate for simple applications, automatic registration simplifies the addition of new notification types and is recommended for most cases.
+
+### Automatic Registration
+
+[`NotificationTypeProvider`](src/main/java/org/octri/notification/registry/NotificationTypeProvider.java) is a convenience interface that allows notification types to be automatically discovered and registered with the type registry. Implementing classes return the objects needed to process a notification type. Most methods have default implementations, so a minimal implementation only needs to provide a unique string to identify the notification and a `NotificationDispatcher`.
+
+```java
+public interface NotificationTypeProvider {
+
+	String getNotificationType();
+
+	default ProcessingMode getProcessingMode() {
+		return ProcessingMode.SCHEDULED;
+	}
+
+	default Class<? extends NotificationMetadata> getNotificationMetadata() {
+		return EmptyMetadata.class;
+	}
+
+	default NotificationValidator getNotificationValidator() {
+		return NotificationValidator.NOOP;
+	};
+
+	NotificationDispatcher getNotificationDispatcher();
+
+	default NotificationViewer getNotificationViewer() {
+		return new EmptyMetadataViewer();
+	}
+
+}
+```
+
+Concrete implementations of `NotificationTypeProvider` can be `@Component` classes that get the needed dependencies through constructor injection.
+
+On application startup, [the library's autoconfiguration](src/main/java/org/octri/notification/config/NotificationAutoConfiguration.java) finds all of the `NotificationTypeProvider` beans in the application context and registers their notifications with the `NotificationTypeRegistry`.
+
+### Manual Registration
+
+To manually register a new notification type, use the [`NotificationTypeRegistry`](src/main/java/org/octri/notification/registry/NotificationTypeRegistry.java) directly.
 
 ```java
 @Component

--- a/src/main/java/org/octri/notification/config/NotificationAutoConfiguration.java
+++ b/src/main/java/org/octri/notification/config/NotificationAutoConfiguration.java
@@ -4,16 +4,22 @@ import org.octri.notification.batch.NotificationBatchJob;
 import org.octri.notification.controller.NotificationController;
 import org.octri.notification.converter.NotificationStatusMvcConverter;
 import org.octri.notification.registry.NotificationStatusRegistry;
+import org.octri.notification.registry.NotificationTypeProvider;
 import org.octri.notification.registry.NotificationTypeRegistry;
 import org.octri.notification.repository.NotificationRepository;
 import org.octri.notification.service.NotificationService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.util.Assert;
 
 /**
  * Configuration for the notification library.
@@ -26,8 +32,10 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @Import({ NotificationBatchConfig.class, TwilioStatusBatchConfig.class, NotificationController.class })
 public class NotificationAutoConfiguration {
 
+	private static final Logger log = LoggerFactory.getLogger(NotificationAutoConfiguration.class);
+
 	/**
-	 * 
+	 *
 	 * @return a bean for the notification type registry
 	 */
 	@Bean
@@ -36,7 +44,7 @@ public class NotificationAutoConfiguration {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return a bean for the notification status registry
 	 */
 	@Bean
@@ -45,7 +53,7 @@ public class NotificationAutoConfiguration {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param notificationStatusRegistry
 	 *            the notification status registry
 	 * @return a bean for the notification status MVC converter
@@ -57,7 +65,7 @@ public class NotificationAutoConfiguration {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param notificationRepository
 	 *            the notification repository
 	 * @param notificationTypeRegistry
@@ -71,6 +79,32 @@ public class NotificationAutoConfiguration {
 			NotificationTypeRegistry notificationTypeRegistry,
 			NotificationBatchJob notificationBatchJob) {
 		return new NotificationService(notificationRepository, notificationTypeRegistry, notificationBatchJob);
+	}
+
+	/**
+	 * Discovers notification types from {@link NotificationTypeProvider} beans and registers them with the
+	 * {@link NotificationTypeRegistry}.
+	 *
+	 * @param event
+	 */
+	@EventListener
+	public void autoRegisterNotificationTypes(ContextRefreshedEvent event) {
+		var applicationContext = event.getApplicationContext();
+		var notificationTypeRegistry = applicationContext.getBean(NotificationTypeRegistry.class);
+		Assert.notNull(notificationTypeRegistry, "NotificationTypeRegistry bean not found in application context");
+
+		log.info("Auto-registering notification types from NotificationTypeProvider beans");
+		applicationContext.getBeansOfType(NotificationTypeProvider.class).values().forEach(provider -> {
+			log.debug("Discovered provider {} for notification type {}", provider.getClass().getSimpleName(),
+					provider.getNotificationType());
+			notificationTypeRegistry.register(
+					provider.getNotificationType(),
+					provider.getProcessingMode(),
+					provider.getNotificationMetadata(),
+					provider.getNotificationValidator(),
+					provider.getNotificationDispatcher(),
+					provider.getNotificationViewer());
+		});
 	}
 
 }

--- a/src/main/java/org/octri/notification/registry/NotificationTypeProvider.java
+++ b/src/main/java/org/octri/notification/registry/NotificationTypeProvider.java
@@ -1,0 +1,68 @@
+package org.octri.notification.registry;
+
+import org.octri.notification.dispatch.NotificationDispatcher;
+import org.octri.notification.domain.ProcessingMode;
+import org.octri.notification.metadata.EmptyMetadata;
+import org.octri.notification.metadata.NotificationMetadata;
+import org.octri.notification.validator.NotificationValidator;
+import org.octri.notification.view.EmptyMetadataViewer;
+import org.octri.notification.view.NotificationViewer;
+
+/**
+ * Interface for objects that provide the dependencies needed to process a type of notification. Notification types
+ * provided by instances of this interface are discovered at runtime and automatically registered with the
+ * {@link NotificationTypeRegistry}.
+ */
+public interface NotificationTypeProvider {
+
+	/**
+	 * Unique type name for this type of notification
+	 *
+	 * @return
+	 */
+	String getNotificationType();
+
+	/**
+	 * Processing mode for this type of notification. Defaults to SCHEDULED.
+	 *
+	 * @return
+	 */
+	default ProcessingMode getProcessingMode() {
+		return ProcessingMode.SCHEDULED;
+	}
+
+	/**
+	 * Class of NotificationMetadata used by this type of notification. Defaults to {@link EmptyMetadata}.
+	 *
+	 * @return
+	 */
+	default Class<? extends NotificationMetadata> getNotificationMetadata() {
+		return EmptyMetadata.class;
+	}
+
+	/**
+	 * Validator used to determine if a notification of this type should be delivered.
+	 *
+	 * @return
+	 */
+	default NotificationValidator getNotificationValidator() {
+		return NotificationValidator.NOOP;
+	};
+
+	/**
+	 * Dispatcher used to deliver notifications of this type.
+	 *
+	 * @return
+	 */
+	NotificationDispatcher getNotificationDispatcher();
+
+	/**
+	 * Viewer used to display metadata for this type of notification. Defaults to {@link EmptyMetadataViewer}.
+	 *
+	 * @return
+	 */
+	default NotificationViewer getNotificationViewer() {
+		return new EmptyMetadataViewer();
+	}
+
+}

--- a/src/main/java/org/octri/notification/registry/NotificationTypeRegistry.java
+++ b/src/main/java/org/octri/notification/registry/NotificationTypeRegistry.java
@@ -23,7 +23,7 @@ public class NotificationTypeRegistry {
 	private final Map<String, NotificationHandler> handlers = new ConcurrentHashMap<>();
 
 	/**
-	 * 
+	 *
 	 * @param type
 	 *            a unique string representation of the Notification type
 	 * @param mode
@@ -45,7 +45,7 @@ public class NotificationTypeRegistry {
 				mode.name(),
 				validator.getClass().getSimpleName(),
 				dispatcher.getClass().getSimpleName(),
-				viewer.getClass().getName());
+				viewer.getClass().getSimpleName());
 		if (handlers.containsKey(type)) {
 			logger.warn("Notification type {} is already registered. Overwriting.", type);
 		}
@@ -53,7 +53,7 @@ public class NotificationTypeRegistry {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return the set of types that are registered
 	 */
 	public Set<String> getRegisteredTypes() {
@@ -61,7 +61,7 @@ public class NotificationTypeRegistry {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param type
 	 *            the type string
 	 * @return the NotificationHandler for the given type


### PR DESCRIPTION
# Overview

Implement a method for autodiscovering notification types.

## Issues

CIS-3607

[X] Added to CHANGELOG.md

## Discussion

This PR implements the notification type discovery mechanism discussed in [this PR comment](https://source.ohsu.edu/OCTRI-Apps/open/pull/344#discussion_r6624). Rather than requiring applications to maintain logic that manually registers notification types with the type registry, with this implementation the objects needed to process a notification type are provided by a `@Bean` or `@Component` that implements the `NotificationTypeProvider` interface. Beans of this type are discovered at application start, and their notification types are automatically registered with the type registry.

An example implementation of `NotificationTypeProvider` would look like the sample below.

```java
@Component
public class BaselineReminderTypeProvider implements NotificationTypeProvider {
 
    public static final String NOTIFICATION_TYPE = "BASELINE_REMINDER";
 
    private final AppConfig appConfig;
    private final AssignmentRepository assignmentRepository;
    private final AuthenticationUrlHelper authenticationUrlHelper;
    private final ParticipantService participantService;
    private final ParticipantWorkflowService participantWorkflowService;
    private final MessageDeliveryService messageDeliveryService;
    private final Mustache.Compiler mustacheCompiler;
    private final NotificationProperties notificationProperties;
 
    public BaselineReminderTypeProvider(AppConfig appConfig, AssignmentRepository assignmentRepository,
            AuthenticationUrlHelper authenticationUrlHelper, MessageDeliveryService messageDeliveryService,
            Mustache.Compiler mustacheCompiler, NotificationProperties notificationProperties,
            ParticipantService participantService, ParticipantWorkflowService participantWorkflowService) {
        this.appConfig = appConfig;
        this.assignmentRepository = assignmentRepository;
        this.authenticationUrlHelper = authenticationUrlHelper;
        this.participantService = participantService;
        this.participantWorkflowService = participantWorkflowService;
        this.messageDeliveryService = messageDeliveryService;
        this.mustacheCompiler = mustacheCompiler;
        this.notificationProperties = notificationProperties;
    }
 
    @Override
    public String getNotificationType() {
        return NOTIFICATION_TYPE;
    }
 
    @Override
    public Class<SurveyReminderMetadata> getNotificationMetadata() {
        return SurveyReminderMetadata.class;
    }
 
    @Override
    public NotificationValidator getNotificationValidator() {
        return new SurveyReminderValidator(assignmentRepository, participantWorkflowService);
    }
 
    @Override
    public NotificationDispatcher getNotificationDispatcher() {
        return new BaselineReminderDispatcher(messageDeliveryService, notificationProperties, mustacheCompiler,
                authenticationUrlHelper, appConfig);
    }
 
    @Override
    public NotificationViewer getNotificationViewer() {
        return new SurveyReminderNotificationViewer(participantService, assignmentRepository, authenticationUrlHelper);
    }
 
}
```
