### PR TITLE
CIS-3709: Upgrade common lib and dependabot config

### DIFF
--- a/.github/workflows/dependabot-changelog-update.xml
+++ b/.github/workflows/dependabot-changelog-update.xml
@@ -1,0 +1,33 @@
+name: Add Dependabot updates to CHANGELOG.md
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+      - labeled
+      - unlabeled
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Add Dependabot changes to CHANGELOG.md
+        uses: dangoslen/dependabot-changelog-helper@v4.3.0
+        with:
+          activationLabels: dependencies
+          changelogPath: './CHANGELOG.md'
+          dependencyTool: dependabot
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v7.1.0
+        with:
+          commit_message: Add Dependabot update to CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to common-lib 2.1.0 and match Spring parent version (CIS-3709)
+
 ## [2.2.0] - 2026-04-17
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.11</version>
 		<relativePath />
 		<!-- lookup parent from repository -->
 	</parent>
@@ -43,7 +43,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
-		<common_lib.version>2.0.1</common_lib.version>
+		<common_lib.version>2.1.0</common_lib.version>
 		<messaginglib.version>0.2.1</messaginglib.version>
 		<node.version>v22.15.0</node.version>
 	</properties>


### PR DESCRIPTION
# Overview

Updates the common-lib, matches the parent pom version, and adds the dependabot configuration for updating the CHANGELOG. This repo did not have a PR already for upgrading the common library, so there may be additional configuration missing.

## Issues

CIS-3709

[X] Added to CHANGELOG.md