### PR TITLE
CIS-3773 Build branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,7 +3,7 @@ name: Build and publish
 on:
   push:
     branches:
-      - '**'
+      - 'main'
   pull_request:
     types:
       - opened


### PR DESCRIPTION
# Overview

Fix the workflow push targeting for `build.yaml`, so that only pushes to `main` trigger the workflow.

## Issues

[CIS-3773](https://jirabp.ohsu.edu/browse/CIS-3773)

[ ] Added to CHANGELOG.md

## Discussion

Recent PR was triggering the build workflow, because I missed the branch targeting update for pushes.