### PR TITLE
CIS-3739 Upgrade messaging-lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumps org.springframework.boot:spring-boot-starter-parent from 3.5.14 to 3.5.16
 - Bumps org.octri.messaging:messaging_lib from 0.2.1 to 0.2.2
 - Bumps org.octri.common:common_lib from 2.1.0 to 2.1.1
+- Bumps org.octri.messaging:messaging_lib from 0.2.2 to 0.2.3
 
 ## [2.2.2] - 2026-06-11
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>17</java.version>
 		<common_lib.version>2.1.1</common_lib.version>
-		<messaginglib.version>0.2.2</messaginglib.version>
+		<messaginglib.version>0.2.3</messaginglib.version>
 		<node.version>v24.16.0</node.version>
 	</properties>
 


### PR DESCRIPTION
# Overview

Upgrade the messaging-lib dependency to 0.2.3 (which updates the Twilio transitive dependency).

## Issues

[CIS-3739](https://jirabp.ohsu.edu/browse/CIS-3739)

[x] Added to CHANGELOG.md

## Discussion

Related to [authentication-lib #89](https://github.com/OHSU-OCTRI/authentication-lib/pull/89), which upgrades the same dependency in authentication-lib. Without upgrading the dependency in both packages, downstream projects may resolve an unexpected version of the transitive Twilio dependency.

Using COMPASS, I tested that this upgrade doesn't break the sending of notifications, and I didn't find anything too incriminating in the changelog - but I'm not sure whether it's possible for this to cause issues reading JSON for existing notifications?